### PR TITLE
style: 💄 Relocate bookmark star to avoid clipping

### DIFF
--- a/packages/upset/src/components/AggregateRow.tsx
+++ b/packages/upset/src/components/AggregateRow.tsx
@@ -94,10 +94,10 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
           showConnectingBar={aggregateRow.aggregateBy !== 'Overlaps'}
         />
       )}
-      <CardinalityBar row={aggregateRow} size={aggregateRow.size} />
       { bookmarkedIntersections.includes(aggregateRow.id) &&
           <BookmarkStar row={aggregateRow} />
       }
+      <CardinalityBar row={aggregateRow} size={aggregateRow.size} />
       <DeviationBar deviation={aggregateRow.deviation} />
     </g>
   );

--- a/packages/upset/src/components/AttributeBars.tsx
+++ b/packages/upset/src/components/AttributeBars.tsx
@@ -19,11 +19,11 @@ export const AttributeBars: FC<Props> = ({ attributes }) => {
     <g
       transform={translate(
         dimensions.matrixColumn.width +
-          dimensions.gap +
-          dimensions.cardinality.width +
           dimensions.bookmarkStar.gap +
           dimensions.bookmarkStar.width +
           dimensions.bookmarkStar.gap +
+          dimensions.cardinality.width +
+          dimensions.gap +
           dimensions.attribute.width +
           dimensions.attribute.vGap,
         (dimensions.body.rowHeight - dimensions.attribute.plotHeight) / 2,

--- a/packages/upset/src/components/BookmarkStar.tsx
+++ b/packages/upset/src/components/BookmarkStar.tsx
@@ -20,9 +20,6 @@ export const BookmarkStar: FC<Props> = ({ row }) => {
         onClick={() => row && (setCurrentIntersectionAtom(row))}
         transform={translate(
             dimensions.matrixColumn.width + 
-            dimensions.bookmarkStar.gap +
-            dimensions.bookmarkStar.gap / 2 +
-            dimensions.cardinality.width + 
             dimensions.bookmarkStar.gap,
             0)}
             css={css`cursor:pointer;`}>

--- a/packages/upset/src/components/CardinalityBar.tsx
+++ b/packages/upset/src/components/CardinalityBar.tsx
@@ -78,7 +78,10 @@ export const CardinalityBar: FC<Props> = ({ row, size }) => {
     <g
       onClick={() => row && (setCurrentIntersectionAtom(row))}
       transform={translate(
-        dimensions.matrixColumn.width + dimensions.gap,
+        dimensions.matrixColumn.width +
+        dimensions.bookmarkStar.gap +
+        dimensions.bookmarkStar.width +
+        dimensions.bookmarkStar.gap,
         (dimensions.body.rowHeight - dimensions.cardinality.plotHeight) / 2,
       )}
       css={rowStyle}

--- a/packages/upset/src/components/DeviationBar.tsx
+++ b/packages/upset/src/components/DeviationBar.tsx
@@ -28,12 +28,12 @@ export const DeviationBar: FC<Props> = ({ deviation }) => {
     <g
       transform={translate(
         dimensions.matrixColumn.width +
-          dimensions.gap +
-          dimensions.cardinality.width +
-          dimensions.bookmarkStar.gap +
-          dimensions.bookmarkStar.width +
-          dimensions.bookmarkStar.gap +
-          dimensions.attribute.width / 2,
+        dimensions.bookmarkStar.gap +
+        dimensions.bookmarkStar.width +
+        dimensions.bookmarkStar.gap +
+        dimensions.cardinality.width +
+        dimensions.gap +
+        dimensions.attribute.width / 2,
         (dimensions.body.rowHeight - dimensions.attribute.plotHeight) / 2,
       )}
     >

--- a/packages/upset/src/components/Header/CardinalityHeader.tsx
+++ b/packages/upset/src/components/Header/CardinalityHeader.tsx
@@ -90,7 +90,10 @@ export const CardinalityHeader: FC = () => {
   return (
     <g
       transform={translate(
-        dimensions.matrixColumn.width + dimensions.gap,
+        dimensions.matrixColumn.width +
+        dimensions.bookmarkStar.gap +
+        dimensions.bookmarkStar.width +
+        dimensions.bookmarkStar.gap,
         dimensions.header.totalHeight - dimensions.cardinality.height,
       )}
     >

--- a/packages/upset/src/components/Header/DeviationHeader.tsx
+++ b/packages/upset/src/components/Header/DeviationHeader.tsx
@@ -15,11 +15,11 @@ export const DeviationHeader = () => {
     <g
       transform={translate(
         dimensions.matrixColumn.width +
-          dimensions.gap +
-          dimensions.cardinality.width +
-          dimensions.bookmarkStar.gap +
-          dimensions.bookmarkStar.width +
-          dimensions.bookmarkStar.gap,
+        dimensions.bookmarkStar.gap +
+        dimensions.bookmarkStar.width +
+        dimensions.bookmarkStar.gap +
+        dimensions.cardinality.width +
+        dimensions.gap,
         dimensions.header.totalHeight - dimensions.attribute.height,
       )}
     >

--- a/packages/upset/src/components/SubsetRow.tsx
+++ b/packages/upset/src/components/SubsetRow.tsx
@@ -26,10 +26,10 @@ export const SubsetRow: FC<Props> = ({ subset }) => {
     <>
       <rect height={dimensions.body.rowHeight} width={dimensions.body.rowWidth} css={currentIntersection !== null && currentIntersection.id === subset.id ? highlight : defaultBackground} rx="5" ry="10"></rect>
       <Matrix sets={visibleSets} subset={subset} />
-      <CardinalityBar size={subset.size} row={subset} />
       {bookmarkedIntersections.includes(subset.id) &&
         <BookmarkStar row={subset} />
       }
+      <CardinalityBar size={subset.size} row={subset} />
       <DeviationBar deviation={subset.deviation} />
       <AttributeBars attributes={subset.attributes} />
     </>

--- a/packages/upset/src/dimensions.ts
+++ b/packages/upset/src/dimensions.ts
@@ -55,6 +55,12 @@ export function calculateDimensions(
       return attribute.width + this.textMargin;
     },
   };
+  
+  const bookmarkStar = {
+    width: 20,
+    height: 24,
+    gap: 10,
+  }
 
   const header = {
     totalWidth:
@@ -62,7 +68,9 @@ export function calculateDimensions(
       set.width * nVisibleSets + // Offset for total sets
       gap + // Add margin
       cardinality.width + // Cardinality
-      gap + //
+      bookmarkStar.gap +
+      bookmarkStar.width + // Bookmark Star
+      bookmarkStar.gap +
       attribute.width + // Deviation
       attribute.vGap +
       (attribute.vGap + attribute.width) * nAttributes, // Show all attributes
@@ -77,13 +85,6 @@ export function calculateDimensions(
       return nIntersections * this.rowHeight;
     },
   };
-
-
-  const bookmarkStar = {
-    width: 20,
-    height: body.rowHeight,
-    gap: 10,
-  }
 
   const totalWidth =
     matrixColumn.totalWidth > header.totalWidth


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
When the set size is 4 or more digits, the bookmark star was clipping. Relocating the star to before the cardinality bar fixes the issue.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...