### PR TITLE
feat: 🎸 Add one-hot encoding for categorical data from multinet

### DIFF
--- a/packages/app/src/atoms/dataAtom.ts
+++ b/packages/app/src/atoms/dataAtom.ts
@@ -1,15 +1,17 @@
-import { process } from '@visdesignlab/upset2-core';
-import { selector } from 'recoil';
+import { CoreUpsetData, process } from '@visdesignlab/upset2-core';
+import { atom, selector } from 'recoil';
 
 import { api } from './authAtoms';
 import { logInStatusSelector } from './loginAtom';
 import { queryParamAtom } from './queryParamAtom';
 
-export const dataAtom = selector({
+export const dataSelector = selector<CoreUpsetData | null>({
   key: 'upset-data',
   get: async ({ get }) => {
     const isLoggedIn = get(logInStatusSelector);
 
+    // public data inaccessible
+    // TODO: Fix
     if (!isLoggedIn) return null;
 
     const { workspace, table } = get(queryParamAtom);
@@ -23,7 +25,12 @@ export const dataAtom = selector({
     ).results;
 
     const annotations = await api.columnTypes(workspace, table);
-
+    
     return process(rows as any, { columns: annotations } as any);
   },
 });
+
+export const encodedDataAtom = atom<CoreUpsetData | null>({
+  key: 'encoded-upset-data',
+  default: null
+})

--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -1,9 +1,7 @@
 import { Upset } from '@visdesignlab/upset2-react';
 import { useRecoilValue } from 'recoil';
-
-import { dataAtom } from '../atoms/dataAtom';
+import { dataSelector, encodedDataAtom } from '../atoms/dataAtom';
 import { doesHaveSavedQueryParam, queryParamAtom } from '../atoms/queryParamAtom';
-
 import { ErrorModal } from './ErrorModal';
 
 type Props = {
@@ -12,22 +10,25 @@ type Props = {
 
 export const Body = ({ yOffset }: Props) => {
   const { workspace, table } = useRecoilValue(queryParamAtom);
-  const data = useRecoilValue(dataAtom);
+  const multinetData = useRecoilValue(dataSelector);
+  const encodedData = useRecoilValue(encodedDataAtom);
+  const data = (encodedData === null) ? multinetData : encodedData
+  
+  if (data === null) return null;
 
-  if ((!workspace || !table) && !doesHaveSavedQueryParam())
+  // if no data has been loaded or if the error/one-hot modal has been closed by the user
+  if (((!workspace || !table) && !doesHaveSavedQueryParam()) || (encodedData !== null && data.setColumns.length === 0))
     return <div>Please click Load Data button to go to data interface.</div>;
-
-  if (!data) return null;
 
   return (
     <div>
-      { data.setColumns.length === 0 ? 
-      <ErrorModal /> :
-      <Upset
+      { data.setColumns.length === 0 ?
+        <ErrorModal />:
+        <Upset
         data={data}
         loadAttributes={3}
         yOffset={yOffset === -1 ? 0 : yOffset}
-      />
+        />
       }
     </div>
   );

--- a/packages/app/src/components/ErrorModal.tsx
+++ b/packages/app/src/components/ErrorModal.tsx
@@ -1,11 +1,112 @@
-import { Dialog, DialogTitle, DialogContent, DialogContentText } from "@mui/material"
+import { useState } from "react";
+import { Dialog, DialogTitle, DialogContent, DialogContentText, FormControl, InputLabel, Checkbox, ListItemText, MenuItem, OutlinedInput, Select, SelectChangeEvent, Button } from "@mui/material"
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { dataSelector, encodedDataAtom } from "../atoms/dataAtom";
+import { CoreUpsetData, process } from "@visdesignlab/upset2-core";
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
 
 export const ErrorModal = () => {
+    const data = useRecoilValue(dataSelector);
+    const setEncodedDataAtom = useSetRecoilState(encodedDataAtom);
+    const [ encodeList, setEncodeList ] = useState<string[]>([]);
+    let needOneHot = false;
+
+    if (data === null) return null;
+
+    if (Object.values(data.columnTypes).includes('category')) {
+        needOneHot = true;
+    }
+
+    const handleChange = (e: SelectChangeEvent) => {
+        const {
+            target: { value },
+          } = e;
+        setEncodeList(typeof value === 'string' ? value.split(',') : value)
+    }
+
+    const oneHotEncode = (empty?: boolean) => {
+        // close the error window and rerender screen by updating the atom
+        if (empty) {
+            setEncodedDataAtom(null);
+        }
+
+        const newColNames: string[] = []
+        const encodedData: CoreUpsetData = structuredClone(data);
+
+        // get the unique names of every new column to be added. 
+        //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
+        encodeList.forEach((s) => Object.entries(data.items).forEach(([id, row]) => {
+            const names = `${row[s]}`.split(',');
+            if (!(names.length === 1 && names[0] === ""))
+                newColNames.push(...names.map((val) => `${s}_${val}`))
+        }))
+        const uniqueColNames: Set<string> = new Set(newColNames);
+
+        // populate the data items group membership
+        Object.entries(encodedData.items).forEach(([id, row]) => {
+            Array.from(uniqueColNames).forEach((col) => {
+                let splitCol = col.split('_');
+                row[col] = `${row[splitCol[0]]}`.includes(splitCol[1])
+            })
+        })
+
+        // fetch the new annotations to pass into process, these are needed to ensure that the columns are added to columnTypes
+        const newAnnotations = Array.from(uniqueColNames).map((col) => {return {[col]: "boolean"}})
+            .reduce((obj, item) => Object.assign(obj, item), {})
+        const annotations = {...encodedData.columnTypes, ...newAnnotations}
+        
+        setEncodedDataAtom(process(Object.values(encodedData.items) as any, { columns: annotations } as any));
+    }
+    
     return (
         <Dialog open={true} >
             <DialogTitle>Error</DialogTitle>
             <DialogContent>
-                <DialogContentText>The provided data is in an incompatible form for visualization with Upset. To visualize this dataset, please upload set-based data.</DialogContentText>
+                <DialogContentText>The provided data is in an incompatible form for visualization with Upset. To visualize this dataset, please upload set-based data or, if compatible, select columns to one-hot encode.</DialogContentText>
+                { needOneHot && 
+                <>
+                <DialogContentText style={{fontWeight:'bold'}}>Choose columns to one-hot encode</DialogContentText>
+                    <div style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center"
+                    }}>
+                        <FormControl sx={{ m: 1, width: 300 }}>
+                            <InputLabel id="multiple-checkbox-label">Columns:</InputLabel>
+                            <Select
+                            labelId="multiple-checkbox-label"
+                            id="multiple-checkbox"
+                            multiple
+                            value={encodeList as any}
+                            onChange={handleChange}
+                            input={<OutlinedInput label="Columns to encode" />}
+                            renderValue={(selected: any) => selected.join(', ')}
+                            MenuProps={MenuProps}
+                            >
+                            {Object.entries(data.columnTypes).map(([name, type]) => (
+                                <MenuItem key={name} value={name}>
+                                <Checkbox checked={encodeList.includes(name)} />
+                                <ListItemText primary={name} />
+                                </MenuItem>
+                            ))}
+                            </Select>
+                        </FormControl>
+
+                        <Button style={{ height: "60%" }} color="error" onClick={() => { encodeList.length = 0; oneHotEncode(true) }}>Cancel</Button>
+                        <Button style={{ height: "60%" }} color="secondary" variant="contained" onClick={() => oneHotEncode()}>Submit</Button>
+                    </div>
+                </>
+                }
             </DialogContent>
         </Dialog>
     )

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -182,6 +182,7 @@ export function process(data: DSVRowArray, meta: Meta): CoreUpsetData {
     setColumns,
     attributeColumns,
     columns: Object.keys(columns),
+    columnTypes: columns,
     items,
     sets,
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,11 +111,16 @@ export type Rows = Subsets | Aggregates;
 
 export type Row = Subset | Aggregate;
 
+export type ColumnTypes = {
+    [key: string]: string;
+}
+
 export type CoreUpsetData = {
   label: ColumnName;
   setColumns: ColumnName[];
   attributeColumns: ColumnName[];
   columns: ColumnName[];
+  columnTypes: ColumnTypes;
   items: Items;
   sets: Sets;
 };


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #135 

### Give a longer description of what this PR addresses and why it's needed
This PR gives the user the ability to select which category or label columns they would like to one-hot encode when loading the data into Upset. 

### Provide pictures/videos of the behavior before and after these changes (optional)
EXAMPLE DATA: 
<img width="224" alt="image" src="https://user-images.githubusercontent.com/35744963/226761935-0c840360-7467-4ca4-bb5d-c7fb8c43f6df.png">
MODAL: 
![image](https://user-images.githubusercontent.com/35744963/226762045-f6d084e0-b3aa-407a-b0a8-7e0255b593d3.png)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] Local edge case testing