### PR TITLE
Sort matrix sets

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,7 +90,7 @@ export type AggregateBy = typeof aggregateByList[number];
 export const sortByList = ['Degree', 'Cardinality', 'Deviation'] as const;
 export type SortBy = typeof sortByList[number];
 
-export const sortVisibleByList = ['Alphabetical', 'Size - Ascending', 'Size - Descending'] as const;
+export const sortVisibleByList = ['Alphabetical', 'Ascending', 'Descending'] as const;
 export type SortVisibleBy = typeof sortVisibleByList[number];
 
 export type Aggregate = Omit<Subset, 'items'> & {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,6 +90,9 @@ export type AggregateBy = typeof aggregateByList[number];
 export const sortByList = ['Degree', 'Cardinality', 'Deviation'] as const;
 export type SortBy = typeof sortByList[number];
 
+export const sortVisibleByList = ['Alphabetical', 'Size - Ascending', 'Size - Descending'] as const;
+export type SortVisibleBy = typeof sortVisibleByList[number];
+
 export type Aggregate = Omit<Subset, 'items'> & {
   aggregateBy: AggregateBy;
   level: number;
@@ -152,6 +155,7 @@ export type UpsetConfig = {
   firstOverlapDegree: number;
   secondAggregateBy: AggregateBy;
   secondOverlapDegree: number;
+  sortVisibleBy: SortVisibleBy;
   sortBy: SortBy;
   filters: {
     maxVisible: number;

--- a/packages/upset/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/upset/src/atoms/config/upsetConfigAtoms.ts
@@ -6,6 +6,7 @@ export const defaultConfig: UpsetConfig = {
   firstOverlapDegree: 2,
   secondAggregateBy: 'None',
   secondOverlapDegree: 2,
+  sortVisibleBy: 'Alphabetical',
   sortBy: 'Cardinality',
   filters: {
     maxVisible: 3,

--- a/packages/upset/src/atoms/config/visibleSetsAtoms.ts
+++ b/packages/upset/src/atoms/config/visibleSetsAtoms.ts
@@ -16,10 +16,10 @@ export const visibleSetSelector = selector<string[]>({
       case 'Alphabetical':
         visibleSetList.sort();
         break;
-      case 'Size - Ascending':
+      case 'Ascending':
         visibleSetList.sort((a, b) => sets[a].size - sets[b].size);
         break;
-      case 'Size - Descending':
+      case 'Descending':
         visibleSetList.sort((a, b) => sets[b].size - sets[a].size);
     }
     return visibleSetList;

--- a/packages/upset/src/atoms/config/visibleSetsAtoms.ts
+++ b/packages/upset/src/atoms/config/visibleSetsAtoms.ts
@@ -2,10 +2,33 @@ import { atom, selector } from 'recoil';
 
 import { setsAtom } from '../setsAtoms';
 import { upsetConfigAtom } from './upsetConfigAtoms';
+import { SortVisibleBy } from '@visdesignlab/upset2-core';
 
 export const visibleSetSelector = selector<string[]>({
   key: 'visible-sets',
-  get: ({ get }) => get(upsetConfigAtom).visibleSets,
+  get: ({ get }) => {
+    const sets = get(setsAtom);
+    const visibleSets = get(upsetConfigAtom).visibleSets;
+    const sortVisibleBy = get(upsetConfigAtom).sortVisibleBy;
+    const visibleSetList = [...visibleSets];
+
+    switch(sortVisibleBy) {
+      case 'Alphabetical':
+        visibleSetList.sort();
+        break;
+      case 'Size - Ascending':
+        visibleSetList.sort((a, b) => sets[a].size - sets[b].size);
+        break;
+      case 'Size - Descending':
+        visibleSetList.sort((a, b) => sets[b].size - sets[a].size);
+    }
+    return visibleSetList;
+  }
+});
+
+export const visibleSortSelector = selector<SortVisibleBy>({
+  key: 'visible-sort-by',
+  get: ({ get }) => get(upsetConfigAtom).sortVisibleBy,
 });
 
 export const hiddenSetSelector = selector<string[]>({

--- a/packages/upset/src/components/Body.tsx
+++ b/packages/upset/src/components/Body.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { dimensionsSelector } from '../atoms/dimensionsAtom';

--- a/packages/upset/src/components/Header/Header.tsx
+++ b/packages/upset/src/components/Header/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AttributeHeaders } from './AttributeHeaders';
 import { CardinalityHeader } from './CardinalityHeader';
 import { DeviationHeader } from './DeviationHeader';

--- a/packages/upset/src/components/Header/MatrixHeader.tsx
+++ b/packages/upset/src/components/Header/MatrixHeader.tsx
@@ -49,13 +49,15 @@ export const MatrixHeader = () => {
         mouseX: e.clientX,
         mouseY: e.clientY,
         id: `${setName}-menu`,
-        items: [{
-          label: `Add ${setName.replace('_', ': ')}`,
-          onClick: () => {
-            actions.addVisibleSet(setName);
-            handleContextMenuClose();
-          }
-        }]
+        items: [
+          {
+            label: `Add ${setName.replace('_', ': ')}`,
+            onClick: () => {
+              actions.addVisibleSet(setName);
+              handleContextMenuClose();
+            }
+          },
+      ]
       }
     );
   }

--- a/packages/upset/src/components/Header/SetHeader.tsx
+++ b/packages/upset/src/components/Header/SetHeader.tsx
@@ -55,20 +55,20 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
                 disabled: sortVisibleBy === 'Alphabetical',
               },
               {
-                label: `Sort matrix headers by size - Ascending`,
+                label: `Sort matrix headers by Size - Ascending`,
                 onClick: () => {
-                  actions.sortVisibleBy('Size - Ascending' as SortVisibleBy);
+                  actions.sortVisibleBy('Ascending' as SortVisibleBy);
                   handleContextMenuClose();
                 },
-                disabled: sortVisibleBy === 'Size - Ascending',
+                disabled: sortVisibleBy === 'Ascending',
               },
               {
-                label: `Sort matrix headers by size - Descending`,
+                label: `Sort matrix headers by Size - Descending`,
                 onClick: () => {
-                  actions.sortVisibleBy('Size - Descending' as SortVisibleBy);
+                  actions.sortVisibleBy('Descending' as SortVisibleBy);
                   handleContextMenuClose();
                 },
-                disabled: sortVisibleBy === 'Size - Descending',
+                disabled: sortVisibleBy === 'Descending',
               },
             ],
           }

--- a/packages/upset/src/components/Header/SetHeader.tsx
+++ b/packages/upset/src/components/Header/SetHeader.tsx
@@ -10,6 +10,8 @@ import { SetLabel } from '../custom/SetLabel';
 import { SetSizeBar } from '../custom/SetSizeBar';
 import { ProvenanceContext } from '../Root';
 import { contextMenuAtom } from '../../atoms/contextMenuAtom';
+import { SortVisibleBy } from '@visdesignlab/upset2-core';
+import { visibleSortSelector } from '../../atoms/config/visibleSetsAtoms';
 
 type Props = {
   visibleSets: string[];
@@ -19,6 +21,7 @@ type Props = {
 export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const sets = useRecoilValue(setsAtom);
+  const sortVisibleBy = useRecoilValue(visibleSortSelector);
   const { actions } = useContext(
     ProvenanceContext,
   );
@@ -34,13 +37,39 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
             mouseX: e.clientX,
             mouseY: e.clientY,
             id: `${setName}-menu`,
-            items: [{
-              label: `Remove ${setName.replace('_', ': ')}`,
-              onClick: () => {
-                actions.removeVisibleSet(setName);
-                handleContextMenuClose();
-              }
-            }],
+            items: [
+              {
+                label: `Remove ${setName.replace('_', ': ')}`,
+                onClick: () => {
+                  actions.removeVisibleSet(setName);
+                  handleContextMenuClose();
+                }
+              },
+              {
+                label: `Sort matrix headers by Alphabetical`,
+                onClick: () => {
+                  actions.sortVisibleBy('Alphabetical' as SortVisibleBy);
+                  handleContextMenuClose();
+                },
+                disabled: sortVisibleBy === 'Alphabetical',
+              },
+              {
+                label: `Sort matrix headers by size - Ascending`,
+                onClick: () => {
+                  actions.sortVisibleBy('Size - Ascending' as SortVisibleBy);
+                  handleContextMenuClose();
+                },
+                disabled: sortVisibleBy === 'Size - Ascending',
+              },
+              {
+                label: `Sort matrix headers by size - Descending`,
+                onClick: () => {
+                  actions.sortVisibleBy('Size - Descending' as SortVisibleBy);
+                  handleContextMenuClose();
+                },
+                disabled: sortVisibleBy === 'Size - Descending',
+              },
+            ],
           }
     );
   }

--- a/packages/upset/src/components/MatrixRows.tsx
+++ b/packages/upset/src/components/MatrixRows.tsx
@@ -1,5 +1,5 @@
 import { isRowAggregate, Row } from '@visdesignlab/upset2-core';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { a, useTransition } from 'react-spring';
 import { useRecoilValue } from 'recoil';
 

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ import {
   Typography,
 } from '@mui/material';
 import { AggregateBy, aggregateByList, SortBy, sortByList } from '@visdesignlab/upset2-core';
-import React, { Fragment, useContext, useEffect, useState } from 'react';
+import { Fragment, useContext, useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import {

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -1,4 +1,4 @@
-import { AggregateBy, Plot, SortBy, UpsetConfig } from '@visdesignlab/upset2-core';
+import { AggregateBy, Plot, SortBy, SortVisibleBy, UpsetConfig } from '@visdesignlab/upset2-core';
 
 import { defaultConfig } from '../atoms/config/upsetConfigAtoms';
 import { Registry, initializeTrrack } from '@trrack/core';
@@ -38,6 +38,13 @@ const secondAggAction = registry.register('second-agg',
 const secondOverlapAction = registry.register('second-overlap',
   (state, overlap) => {
     state.secondOverlapDegree = overlap;
+    return state;
+  },
+);
+
+const sortVisibleSetsAction = registry.register('sort-visible-by',
+  (state, sort) => {
+    state.sortVisibleBy = sort;
     return state;
   },
 );
@@ -223,6 +230,8 @@ export function getActions(provenance: UpsetProvenance) {
       provenance.apply(
         `Second overlap by ${overlap}`, secondOverlapAction(overlap),
       ),
+    sortVisibleBy: (sort: SortVisibleBy) =>
+        provenance.apply(`Sort Visible Sets by ${sort}`, sortVisibleSetsAction(sort)),
     sortBy: (sort: SortBy) =>
       provenance.apply(`Sort by ${sort}`, sortByAction(sort)),
     setMaxVisible: (val: number) =>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #10 

### Give a longer description of what this PR addresses and why it's needed
This PR adds the ability to sort the matrix header sets via Alphabetical, Size - Ascending, and Size - Descending. This is done via context menu. (( Drag & Drop to be added after #110 , see #137 ))

### Provide pictures/videos of the behavior before and after these changes (optional)
https://user-images.githubusercontent.com/35744963/227030280-afd05f73-d705-4175-affe-8848d7558705.mov

After actions taken in above video:
![image](https://user-images.githubusercontent.com/35744963/227030616-49cbd000-18c0-41cb-bb73-81926a6f06a4.png)

JSON grammar: **Note "sortVisibleBy"**
```
{
  "firstAggregateBy": "None",
  "firstOverlapDegree": 2,
  "secondAggregateBy": "None",
  "secondOverlapDegree": 2,
  "sortVisibleBy": "Size - Ascending",
  "sortBy": "Cardinality",
  "filters": {
    "maxVisible": 3,
    "minVisible": 0,
    "hideEmpty": true
  },
  "visibleSets": [
    "Set_Action",
    "Set_Adventure",
    "Set_Children",
    "Set_Comedy",
    "Set_Crime",
    "Set_Drama",
    "Set_Documentary",
    "Set_SciFi",
    "Set_Romance"
  ],
  "visibleAttributes": [
    "ReleaseDate",
    "AvgRating",
    "Watches"
  ],
  "bookmarkedIntersections": [],
  "plots": {
    "scatterplots": [],
    "histograms": [],
    "wordClouds": []
  }
}
```

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] Local Testing