### PR TITLE
refactor: 💡 collapse state stored in provenance and grammar

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,6 +161,7 @@ export type UpsetConfig = {
   visibleSets: ColumnName[];
   visibleAttributes: ColumnName[];
   bookmarkedIntersections: Bookmark[];
+  collapsed: string[];
   plots: {
     scatterplots: Scatterplot[];
     histograms: Histogram[];

--- a/packages/upset/src/atoms/collapsedAtom.ts
+++ b/packages/upset/src/atoms/collapsedAtom.ts
@@ -1,39 +1,10 @@
-import { Row, isRowAggregate } from '@visdesignlab/upset2-core';
-import { atom, selector } from 'recoil';
-import { rowsSelector } from './renderRowsAtom';
+import { selector } from 'recoil';
+import { upsetConfigAtom } from './config/upsetConfigAtoms';
 
-type CollapsedState = { [id: string]: boolean }
-
-export const defaultCollapsedIntersections = selector<CollapsedState>({
+export const collapsedSelector = selector<string[]>({
   key: 'collapsed-selector',
   get: ({ get }) => {
-    const rows = get(rowsSelector);
-    const ids: CollapsedState = {};
-    Object.entries(rows.values).forEach((entry) => {
-      const row = entry[1];
-      if(isRowAggregate(row)) {
-        ids[row.id] = false;
-      }
-    })
-
-    return ids;
+    const collapsed = get(upsetConfigAtom).collapsed;
+    return collapsed;
   }
 });
-
-export const collapsedAtom = atom<CollapsedState>({
-  key: 'collapsed-ids',
-  default: defaultCollapsedIntersections,
-});
-
-export const getChildrenCollapseState = (row: Row, collapseState: boolean, children: CollapsedState): CollapsedState => {
-  if (!isRowAggregate(row)) {
-    return {...children, [row.id]: collapseState}
-  } else {
-    children[row.id] = collapseState; // add the aggregate-id to the dictionary
-    for (const [_id, set] of Object.entries(row.items.values)) {
-      children = getChildrenCollapseState(set, collapseState, children);
-    }
-  }
-
-  return children;
-}

--- a/packages/upset/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/upset/src/atoms/config/upsetConfigAtoms.ts
@@ -15,6 +15,7 @@ export const defaultConfig: UpsetConfig = {
   visibleSets: [],
   visibleAttributes: [],
   bookmarkedIntersections: [],
+  collapsed: [],
   plots: {
     scatterplots: [],
     histograms: [],

--- a/packages/upset/src/components/Header/CollapseAllButton.tsx
+++ b/packages/upset/src/components/Header/CollapseAllButton.tsx
@@ -1,12 +1,14 @@
-import { DoubleArrow } from "@mui/icons-material";
-import Group from "../custom/Group";
 import { css, SvgIcon, Tooltip } from "@mui/material";
-import { collapsedAtom } from "../../atoms/collapsedAtom";
-import { useRecoilState, useRecoilValue } from "recoil";
-import { useState } from "react";
+import { DoubleArrow } from "@mui/icons-material";
+import { isRowAggregate } from "@visdesignlab/upset2-core";
+import { useRecoilValue } from "recoil";
+import { useContext, useState } from "react";
+import Group from "../custom/Group";
+import { mousePointer } from '../../utils/styles';
+import { ProvenanceContext } from "../Root";
 import { firstAggregateSelector } from "../../atoms/config/aggregateAtoms";
 import { dimensionsSelector } from "../../atoms/dimensionsAtom";
-import { mousePointer } from '../../utils/styles';
+import { rowsSelector } from "../../atoms/renderRowsAtom";
 
 const iconSize = 16;
 
@@ -20,21 +22,31 @@ const collapseAllStyle = css`
 `;
 
 export const CollapseAllButton = () => {
-    const [ collapsedIds, setCollapsedIds ] = useRecoilState(collapsedAtom);
     const firstAggregateBy = useRecoilValue(firstAggregateSelector);
     const dimensions = useRecoilValue(dimensionsSelector);
-
+    const { actions } = useContext(ProvenanceContext);
+    const rows = useRecoilValue(rowsSelector);
     const [ allCollapsed, setAllCollapsed ] = useState(false);
 
     const toggleCollapseAll = () => {
-      const collapsed = !allCollapsed;
-      const ids: {[id: string]: boolean} = {};
-      Object.entries(collapsedIds).forEach((entry) => {
-        ids[entry[0]] = collapsed;
-      })
-  
-      setAllCollapsed(collapsed);
-      setCollapsedIds(ids);
+        const collapsed = !allCollapsed;
+        const ids: string[] = [];
+
+        if (allCollapsed === true) {
+            actions.expandAll();
+            setAllCollapsed(collapsed);
+            return;
+        }
+
+        Object.entries(rows.values).forEach((entry) => {
+            const row = entry[1];
+            if(isRowAggregate(row)) {
+                ids.push(row.id);
+            }
+        })
+    
+        setAllCollapsed(collapsed);
+        actions.collapseAll(ids);
     }
     
     const getTransform = () => {

--- a/packages/upset/src/components/Header/CollapseAllButton.tsx
+++ b/packages/upset/src/components/Header/CollapseAllButton.tsx
@@ -29,24 +29,23 @@ export const CollapseAllButton = () => {
     const [ allCollapsed, setAllCollapsed ] = useState(false);
 
     const toggleCollapseAll = () => {
-        const collapsed = !allCollapsed;
         const ids: string[] = [];
 
         if (allCollapsed === true) {
             actions.expandAll();
-            setAllCollapsed(collapsed);
-            return;
+            setAllCollapsed(false);
         }
-
-        Object.entries(rows.values).forEach((entry) => {
+        else {
+            Object.entries(rows.values).forEach((entry) => {
             const row = entry[1];
             if(isRowAggregate(row)) {
                 ids.push(row.id);
             }
         })
     
-        setAllCollapsed(collapsed);
-        actions.collapseAll(ids);
+            setAllCollapsed(true);
+            actions.collapseAll(ids);
+        }
     }
     
     const getTransform = () => {

--- a/packages/upset/src/components/MatrixRows.tsx
+++ b/packages/upset/src/components/MatrixRows.tsx
@@ -8,7 +8,7 @@ import { RenderRow } from '../atoms/renderRowsAtom';
 import translate from '../utils/transform';
 import { AggregateRow } from './AggregateRow';
 import { SubsetRow } from './SubsetRow';
-import { collapsedAtom } from '../atoms/collapsedAtom';
+import { collapsedSelector } from '../atoms/collapsedAtom';
 
 type Props = {
   rows: RenderRow[];
@@ -24,7 +24,7 @@ export function rowRenderer(row: Row) {
 
 export const MatrixRows: FC<Props> = ({ rows }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
-  const collapsedIds = useRecoilValue(collapsedAtom);
+  const collapsedIds = useRecoilValue(collapsedSelector);
   let numRowsToRender = 0;
   
   const shouldRender = (row: Row) => {
@@ -34,12 +34,12 @@ export const MatrixRows: FC<Props> = ({ rows }) => {
 
     if (parentId.includes('-')) {
       const topLevelAggId = parentId.substring(0,parentId.indexOf('-'));
-      if (collapsedIds[topLevelAggId] === true) {
+      if (collapsedIds.includes(topLevelAggId)) {
         return false;
       }
     }
 
-    if (collapsedIds[parentId] === true) return false;
+    if (collapsedIds.includes(parentId)) return false;
 
     return true;
   }

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import { AggregateBy, aggregateByList, SortBy, sortByList } from '@visdesignlab/upset2-core';
 import { Fragment, useContext, useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import {
   firstAggregateSelector,

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import { AggregateBy, aggregateByList, SortBy, sortByList } from '@visdesignlab/upset2-core';
 import React, { Fragment, useContext, useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import {
   firstAggregateSelector,
@@ -34,7 +34,6 @@ import { sortBySelector } from '../atoms/config/sortByAtom';
 import { visibleSetSelector } from '../atoms/config/visibleSetsAtoms';
 import { ProvenanceContext } from './Root';
 import { exportStateGrammar, ImportModal } from './ImportModal';
-import { collapsedAtom } from '../atoms/collapsedAtom';
 import { provenanceVisAtom } from '../atoms/provenanceVisAtom';
 import { elementSidebarAtom } from '../atoms/elementSidebarAtom';
 
@@ -54,7 +53,6 @@ export const Sidebar = () => {
   const minVisible = useRecoilValue(minVisibleSelector);
   const hideEmpty = useRecoilValue(hideEmptySelector);
 
-  const resetCollapsedIds = useResetRecoilState(collapsedAtom);
   const setHideElementSidebar = useSetRecoilState(elementSidebarAtom);
   const [ provenanceVis, setProvenanceVis ] = useRecoilState(provenanceVisAtom);
 
@@ -150,7 +148,6 @@ export const Sidebar = () => {
             <RadioGroup
               value={firstAggregateBy}
               onChange={ev => {
-                resetCollapsedIds();
                 const newAggBy: AggregateBy = ev.target.value as AggregateBy;
                 actions.firstAggregateBy(newAggBy);
               }}
@@ -199,7 +196,6 @@ export const Sidebar = () => {
             <RadioGroup
               value={secondAggregateBy}
               onChange={ev => {
-                resetCollapsedIds();
                 const newAggBy: AggregateBy = ev.target.value as AggregateBy;
                 actions.secondAggregateBy(newAggBy);
               }}

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -17,6 +17,7 @@ const firstAggAction = registry.register('first-agg',
     if (aggBy === 'None' || aggBy === state.secondAggregateBy) {
       state.secondAggregateBy = 'None';
     }
+    state.collapsed.length = 0; // reset collapsed state without triggering trrack event
     return state;
   },
 );
@@ -31,6 +32,7 @@ const firstOverlapAction = registry.register('first-overlap',
 const secondAggAction = registry.register('second-agg',
   (state, aggBy) => {
     state.secondAggregateBy = aggBy;
+    state.collapsed.length = 0; // reset collapsed state without triggering trrack event
     return state;
   },
 );
@@ -182,7 +184,37 @@ const removePlotAction = registry.register('remove-plot',
 const replaceStateAction = registry.register('set-state',
   (_state: UpsetConfig, newState: UpsetConfig) => {
     return newState;
-  });
+  },
+);
+
+const addCollapsedAction = registry.register('add-collapsed',
+  (state, id) => {
+    const newCollapsed = new Set([...state.collapsed, id]);
+    state.collapsed = Array.from(newCollapsed).sort();
+    return state;
+  },
+);
+
+const removeCollapsedAction = registry.register('remove-collapsed',
+  (state: UpsetConfig, id) => {
+    state.collapsed = state.collapsed.filter((v) => v !== id);
+    return state;
+  },
+);
+
+const collapseAllAction = registry.register('collapse-all', 
+  (state, ids) => {
+    state.collapsed = ids.sort();
+    return state;
+  },
+);
+
+const expandAllAction = registry.register('expand-all', 
+  (state: UpsetConfig, newCollapsed) => {
+    state.collapsed = [...newCollapsed];
+    return state;
+  },
+);
 
 export function initializeProvenanceTracking(
   config: Partial<UpsetConfig> = {},
@@ -268,11 +300,33 @@ export function getActions(provenance: UpsetProvenance) {
         `Unbookmark ${label}`, removeBookmarkIntersectionAction({id, label, size}),
       ),
     addPlot: (plot: Plot) =>
-      provenance.apply(`Add ${plot}`, addPlotAction(plot)),
+      provenance.apply(
+        `Add ${plot}`, addPlotAction(plot)
+      ),
     removePlot: (plot: Plot) =>
-      provenance.apply(`Remove ${plot}`, removePlotAction(plot)),
+      provenance.apply(
+        `Remove ${plot}`, removePlotAction(plot)
+      ),
     replaceState: (state: UpsetConfig) =>
-        provenance.apply(`Replace state`, replaceStateAction(state)),
+        provenance.apply(
+          `Replace state`, replaceStateAction(state)
+        ),
+    addCollapsed: (id: string) => 
+        provenance.apply(
+          `Collapsed ${id}`, addCollapsedAction(id)
+        ),
+    removeCollapsed: (id: string) =>
+        provenance.apply(
+          `Expanded ${id}`, removeCollapsedAction(id)
+        ),
+    collapseAll: (ids: string[]) =>
+        provenance.apply(
+          `Collapsed all rows`, collapseAllAction(ids)
+        ),
+    expandAll: () =>
+        provenance.apply(
+          `Expanded all rows`, expandAllAction([])
+        ),
   };
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #139 

### Give a longer description of what this PR addresses and why it's needed
This PR adds the collapsed ids to the provenance and the grammar as a list of strings. Collapse all appends all ids to the array in a single provenance action. Similarly, expand all removes all items in a single action.

### Provide pictures/videos of the behavior before and after these changes (optional)
Provenance example:
![image](https://user-images.githubusercontent.com/35744963/227057798-6eeed061-b6f0-4dc3-b9b0-03d368d618ee.png)

Exported grammar from the state pictured above: 
```
{
  "firstAggregateBy": "Degree",
  "firstOverlapDegree": 2,
  "secondAggregateBy": "Sets",
  "secondOverlapDegree": 2,
  "sortBy": "Cardinality",
  "filters": {
    "maxVisible": 3,
    "minVisible": 0,
    "hideEmpty": true
  },
  "visibleSets": [
    "Set_Action",
    "Set_Adventure",
    "Set_Children",
    "Set_Comedy",
    "Set_Crime",
    "Set_Documentary"
  ],
  "visibleAttributes": [
    "ReleaseDate",
    "AvgRating",
    "Watches"
  ],
  "bookmarkedIntersections": [],
  "collapsed": [
    "Agg_Degree_0",
    "Agg_Degree_1",
    "Agg_Degree_1-Agg_Comedy",
    "Agg_Degree_2-Agg_Action",
    "Agg_Degree_2-Agg_Children",
    "Agg_Degree_3-Agg_Crime",
    "Agg_Degree_4"
  ],
  "plots": {
    "scatterplots": [],
    "histograms": [],
    "wordClouds": []
  }
}
```

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] Local testing