### PR TITLE
fix: 🐛 Degree sort now properly populates with visible set sort

### DIFF
--- a/packages/upset/src/atoms/renderRowsAtom.ts
+++ b/packages/upset/src/atoms/renderRowsAtom.ts
@@ -6,6 +6,7 @@ import {
   Row,
   Rows,
   secondAggregation,
+  Sets,
   sortRows,
 } from '@visdesignlab/upset2-core';
 import { selector } from 'recoil';
@@ -23,6 +24,7 @@ import { dimensionsSelector } from './dimensionsAtom';
 import { itemsAtom } from './itemsAtoms';
 import { setsAtom } from './setsAtoms';
 import { subsetSelector } from './subsetAtoms';
+import { visibleSetSelector, visibleSortSelector } from './config/visibleSetsAtoms';
 
 const firstAggRRSelector = selector<Rows>({
   key: 'first-aggregate-render-row',
@@ -76,8 +78,13 @@ const sortByRRSelector = selector<Rows>({
   get: ({ get }) => {
     const sortBy = get(sortBySelector);
     const rr = get(secondAggRRSelector);
+    const vSetSortBy = get(visibleSortSelector);
+    const sets = get(setsAtom);
+    const visibleSetNames = get(visibleSetSelector);
 
-    return sortRows(rr, sortBy);
+    const visibleSets: Sets = Object.fromEntries(Object.entries(sets).filter(([name, _set]) => visibleSetNames.includes(name)));
+
+    return sortRows(rr, sortBy, vSetSortBy, visibleSets);
   },
 });
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #148 

### Give a longer description of what this PR addresses and why it's needed
This PR fixes the degree based sorting populating in the incorrect order (compared to visible sets).

### Provide pictures/videos of the behavior before and after these changes (optional)
BEFORE:
![image](https://user-images.githubusercontent.com/35744963/231281981-d5be296c-4579-4e40-9058-5d0946dc638f.png)


AFTER: 
![image](https://user-images.githubusercontent.com/35744963/231281827-17dea00d-565e-44d9-9f19-733478106ee1.png)
![image](https://user-images.githubusercontent.com/35744963/231281887-5b522b56-7d46-43fd-be2b-1a9ce22ad626.png)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] Nope 🍡 