### PR TITLE
feat: 🎸 Filter intersections UI update

### DIFF
--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   FormControl,
   FormControlLabel,
   FormGroup,
+  FormLabel,
   Radio,
   RadioGroup,
   Switch,
@@ -35,6 +36,10 @@ import { dimensionsSelector } from '../atoms/dimensionsAtom';
 const itemDivCSS = css`
   display: flex;
   justify-content: space-between;
+`;
+
+const sidebarHeaderCSS = css`
+  font-size: 0.95rem;
 `;
 
 /** @jsxImportSource @emotion/react */
@@ -73,7 +78,7 @@ export const Sidebar = () => {
     >
       <Accordion disableGutters defaultExpanded>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography>Sorting</Typography>
+          <Typography css={sidebarHeaderCSS}>Sorting</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl>
@@ -86,7 +91,7 @@ export const Sidebar = () => {
               {sortByList.map(sort => {
                 return ( sort === "Deviation" ?
                 (
-                  <Alert severity="info" variant="outlined" key={sort} sx={{ alignItems: 'center', padding: "0.1em 0.4em", marginTop: "0.5em"}}>Use column headers for custom sorting</Alert>
+                  <Alert severity="info" variant="outlined" key={sort} sx={{ alignItems: 'center', padding: "0.1em 0.4em", marginTop: "0.5em"}}><Typography>Use column headers for custom sorting</Typography></Alert>
                 ):
                 (
                   <div css={itemDivCSS} key={sort}>
@@ -105,7 +110,7 @@ export const Sidebar = () => {
       </Accordion>
       <Accordion disableGutters>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography>Aggregation</Typography>
+          <Typography css={sidebarHeaderCSS}>Aggregation</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl sx={{width: "100%"}}>
@@ -156,7 +161,7 @@ export const Sidebar = () => {
         disabled={firstAggregateBy === 'None'}
       >
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography>Second Aggregation</Typography>
+          <Typography css={sidebarHeaderCSS}>Second Aggregation</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl sx={{width: "100%"}}>
@@ -202,12 +207,13 @@ export const Sidebar = () => {
       </Accordion>
       <Accordion disableGutters>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography>Filter Intersections</Typography>
+          <Typography css={sidebarHeaderCSS}>Filter Intersections</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormGroup sx={{ mb: 2.5, width: '100%' }}>
             <div css={itemDivCSS}>
               <FormControlLabel
+                sx={{ ml: 0, '& span': { fontSize: "0.8rem" } }}
                 label="Hide Empty Intersections"
                 control={
                   <Switch
@@ -220,9 +226,16 @@ export const Sidebar = () => {
                 }
                 labelPlacement="start"
               />
-              <HelpCircle text={helpText.filter.HideEmptySets} margin={{...defaultMargin, left: 12}}/>
+              <HelpCircle text={helpText.filter.HideEmptySets} margin={{...defaultMargin, left: 12}} />
             </div>
           </FormGroup>
+          <FormGroup>
+            <div css={itemDivCSS}>
+              <FormLabel>
+                <Typography>Filter by Degree</Typography>
+              </FormLabel>
+              <HelpCircle text={helpText.filter.degree} />
+            </div>
           <div css={itemDivCSS}>
             <TextField
               size="small"
@@ -246,7 +259,6 @@ export const Sidebar = () => {
                 actions.setMinVisible(val);
               }}
             />
-            <HelpCircle text={helpText.filter.MinDegree} />
           </div>
           <div css={itemDivCSS}>
             <TextField
@@ -272,8 +284,8 @@ export const Sidebar = () => {
                 actions.setMaxVisible(val);
               }}
             />
-            <HelpCircle text={helpText.filter.MaxDegree} />
           </div>
+          </FormGroup>
         </AccordionDetails>
       </Accordion>
     </div>

--- a/packages/upset/src/utils/helpText.ts
+++ b/packages/upset/src/utils/helpText.ts
@@ -11,7 +11,6 @@ export const helpText = {
     },
     filter: {
         HideEmptySets: "Hide all subsets that contain no items",
-        MinDegree: "Filter out subsets below the minimum number of overlaps",
-        MaxDegree: "Filter out subsets above the maximum number of overlaps",
+        degree: "Show only intersections that have a degree higher than the \"Min Degree\" and lower than the \"Max Degree\" value."
     }
 }

--- a/packages/upset/src/utils/theme.ts
+++ b/packages/upset/src/utils/theme.ts
@@ -39,6 +39,13 @@ const theme: ThemeOptions = {
           color: "rgba(116, 173, 209, 0.94)"
         }
       }
+    },
+    MuiTypography: {
+      styleOverrides: {
+        body1: {
+          fontSize: "0.9rem"
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #119 

### Give a longer description of what this PR addresses and why it's needed
Addresses comments by @alexsb on filter intersections: 

> Also, we probably need a bit more instructions for the Less Than / More Than.
We should probably say "Filter by Degree" as a title, and add a question mark icon and provide help text:
"Show only intersections that have a degree higher than the "More Than" and lower than the "Less Than" value.

Uses `Min Degree` and `Max Degree` rather than `More Than` and `Less Than`. I feel like this verbiage is more verbose and understandable without tool-tips.

The tool-tip for the min and max degrees was relocated to the new sub-header `Filter By Degree`, which says "Show only intersections that have a degree higher than the "Min Degree" and lower than the "Max Degree" value"

Also, the font size for the entire sidebar was reduced to `0.9rem` and the font size for headers was changed to `0.95rem`. `Hide Empty Intersections` is set to `0.8rem` to avoid a line-break.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://user-images.githubusercontent.com/35744963/235736935-9fa85970-7862-42fd-a33f-e365a5f14a76.png)