### PR TITLE
Import mismatch fix

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
       if (config.visibleSets.length === 0) {
         const setList = Object.keys(data.sets);
         conf.visibleSets = setList.slice(0, 6);
-        conf.hiddenSets = setList.slice(6);
+        conf.allSets = setList;
       }
       
       conf.visibleAttributes = data.attributeColumns.slice(0, 3);

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
       if (config.visibleSets.length === 0) {
         const setList = Object.keys(data.sets);
         conf.visibleSets = setList.slice(0, 6);
+        conf.hiddenSets = setList.slice(6);
       }
       
       conf.visibleAttributes = data.attributeColumns.slice(0, 3);

--- a/packages/app/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/app/src/atoms/config/upsetConfigAtoms.ts
@@ -14,6 +14,7 @@ export const defaultConfig: UpsetConfig = {
     hideEmpty: true,
   },
   visibleSets: [],
+  hiddenSets: [],
   visibleAttributes: [],
   bookmarkedIntersections: [],
   collapsed: [],

--- a/packages/app/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/app/src/atoms/config/upsetConfigAtoms.ts
@@ -14,7 +14,6 @@ export const defaultConfig: UpsetConfig = {
     hideEmpty: true,
   },
   visibleSets: [],
-  hiddenSets: [],
   visibleAttributes: [],
   bookmarkedIntersections: [],
   collapsed: [],
@@ -23,9 +22,10 @@ export const defaultConfig: UpsetConfig = {
     histograms: [],
     wordClouds: [],
   },
+  allSets: [],
 };
 
 export const upsetConfigAtom = atom<UpsetConfig>({
-  key: 'upset-config',
+  key: 'app-config',
   default: defaultConfig,
 });

--- a/packages/app/src/atoms/importErrorAtom.ts
+++ b/packages/app/src/atoms/importErrorAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const importErrorAtom = atom({
+    key: 'import-error-atom',
+    default: false,
+});

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -3,8 +3,8 @@ import { getRows } from '@visdesignlab/upset2-core';
 import RedoIcon from '@mui/icons-material/Redo';
 import UndoIcon from '@mui/icons-material/Undo';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { AccountCircle } from '@mui/icons-material';
-import { AppBar, Box, Button, ButtonGroup, IconButton, Menu, MenuItem, Toolbar, Typography } from '@mui/material';
+import { AccountCircle, ErrorOutline } from '@mui/icons-material';
+import { AppBar, Box, Button, ButtonGroup, IconButton, Menu, MenuItem, Toolbar, Tooltip, Typography } from '@mui/material';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import React, { useContext, useState } from 'react';
 
@@ -14,11 +14,13 @@ import { provenanceVisAtom } from '../../atoms/provenanceVisAtom';
 import { elementSidebarAtom } from '../../atoms/elementSidebarAtom';
 import { ProvenanceContext } from '../Root';
 import { ImportModal } from '../ImportModal';
+import { importErrorAtom } from '../../atoms/importErrorAtom';
 
 const Header = ({ data }: { data: any }) => {
   const { workspace } = useRecoilValue(queryParamAtom);
   const [ isProvVisOpen, setIsProvVisOpen ] = useRecoilState(provenanceVisAtom);
   const [ isElementSidebarOpen, setIsElementSidebarOpen ] = useRecoilState(elementSidebarAtom);
+  const importError = useRecoilValue(importErrorAtom);
   
   const { provenance, isAtRoot, isAtLatest } = useContext(ProvenanceContext);
 
@@ -62,6 +64,11 @@ const Header = ({ data }: { data: any }) => {
           </ButtonGroup>
         </Box>
         <Box sx={{display:'flex', alignItems: 'center', margin: 0, padding: 0}}>
+          {importError &&
+            <Tooltip title={"The imported state is missing fields. Default values have been used."} arrow={true}>
+              <ErrorOutline color="error" sx={{ mr: "10px" }} />
+            </Tooltip> 
+          }
           <Button
             color="inherit"
             onClick={() => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -169,6 +169,7 @@ export type UpsetConfig = {
   };
   visibleSets: ColumnName[];
   visibleAttributes: ColumnName[];
+  hiddenSets: ColumnName[];
   bookmarkedIntersections: Bookmark[];
   collapsed: string[];
   plots: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -169,7 +169,6 @@ export type UpsetConfig = {
   };
   visibleSets: ColumnName[];
   visibleAttributes: ColumnName[];
-  hiddenSets: ColumnName[];
   bookmarkedIntersections: Bookmark[];
   collapsed: string[];
   plots: {
@@ -177,6 +176,7 @@ export type UpsetConfig = {
     histograms: Histogram[];
     wordClouds: WordCloud[];
   };
+  allSets: ColumnName[];
 };
 
 export type AccessibleDataEntry = {

--- a/packages/upset/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/upset/src/atoms/config/upsetConfigAtoms.ts
@@ -15,6 +15,7 @@ export const defaultConfig: UpsetConfig = {
   },
   visibleSets: [],
   visibleAttributes: [],
+  hiddenSets: [],
   bookmarkedIntersections: [],
   collapsed: [],
   plots: {

--- a/packages/upset/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/upset/src/atoms/config/upsetConfigAtoms.ts
@@ -15,7 +15,6 @@ export const defaultConfig: UpsetConfig = {
   },
   visibleSets: [],
   visibleAttributes: [],
-  hiddenSets: [],
   bookmarkedIntersections: [],
   collapsed: [],
   plots: {
@@ -23,6 +22,7 @@ export const defaultConfig: UpsetConfig = {
     histograms: [],
     wordClouds: [],
   },
+  allSets: [],
 };
 
 export const upsetConfigAtom = atom<UpsetConfig>({

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -29,6 +29,8 @@ export type UpsetProps = {
   };
 };
 
+const defaultVisibleSets = 6;
+
 export const Upset: FC<UpsetProps> = ({
   data,
   parentHasHeight = false,
@@ -46,7 +48,8 @@ export const Upset: FC<UpsetProps> = ({
 
     if (conf.visibleSets.length === 0) {
       const setList = Object.keys(data.sets);
-      conf.visibleSets = setList.slice(0, 6);
+      conf.visibleSets = setList.slice(0, defaultVisibleSets);
+      conf.hiddenSets = setList.slice(defaultVisibleSets);
     }
 
     conf.visibleAttributes = data.attributeColumns.slice(0, loadAttributes);

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -49,7 +49,7 @@ export const Upset: FC<UpsetProps> = ({
     if (conf.visibleSets.length === 0) {
       const setList = Object.keys(data.sets);
       conf.visibleSets = setList.slice(0, defaultVisibleSets);
-      conf.hiddenSets = setList.slice(defaultVisibleSets);
+      conf.allSets = setList;
     }
 
     conf.visibleAttributes = data.attributeColumns.slice(0, loadAttributes);

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -80,9 +80,10 @@ const hideEmptyAction = registry.register('hide-empty',
 );
 
 const addToVisibleAction = registry.register('add-to-visible',
-  (state, newSet) => {
+  (state: UpsetConfig, newSet) => {
     const newSets = new Set([...state.visibleSets, newSet]);
     state.visibleSets = Array.from(newSets);
+    state.hiddenSets = state.hiddenSets.filter((s) => s !== newSet);
     return state;
   },
 );
@@ -90,6 +91,8 @@ const addToVisibleAction = registry.register('add-to-visible',
 const removeFromVisibleAction = registry.register('remove-from-visible',
   (state: UpsetConfig, newSet) => {
     state.visibleSets = state.visibleSets.filter((v) => v !== newSet);
+    state.hiddenSets = Array.from(new Set([...state.hiddenSets, newSet]));
+
     return state;
   },
 );
@@ -189,10 +192,10 @@ const removePlotAction = registry.register('remove-plot',
 );
 
 const replaceStateAction = registry.register('set-state',
-  (_state: UpsetConfig, newState: UpsetConfig) => {
+  (state: UpsetConfig, newState: UpsetConfig) => {
     const replacement = JSON.parse(JSON.stringify(newState));
 
-    Object.entries(defaultConfig).forEach(([entry, val]) => {
+    Object.entries(state).forEach(([entry, val]) => {
       if (!Object.keys(replacement).includes(entry)) {
         console.error(`${entry} is missing. Adding default value`);
         

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -83,7 +83,6 @@ const addToVisibleAction = registry.register('add-to-visible',
   (state: UpsetConfig, newSet) => {
     const newSets = new Set([...state.visibleSets, newSet]);
     state.visibleSets = Array.from(newSets);
-    state.hiddenSets = state.hiddenSets.filter((s) => s !== newSet);
     return state;
   },
 );
@@ -91,8 +90,6 @@ const addToVisibleAction = registry.register('add-to-visible',
 const removeFromVisibleAction = registry.register('remove-from-visible',
   (state: UpsetConfig, newSet) => {
     state.visibleSets = state.visibleSets.filter((v) => v !== newSet);
-    state.hiddenSets = Array.from(new Set([...state.hiddenSets, newSet]));
-
     return state;
   },
 );
@@ -201,11 +198,21 @@ const replaceStateAction = registry.register('set-state',
         
         replacement[entry] = val;
       } else if (typeof val === "object" && val !== null) {
-        Object.entries(val).forEach(([key, value]) => {
-          if (replacement[entry][key] === undefined) {
-            replacement[entry][key] = value;
-          }
-        })
+        /* 
+         * Remove the duplicate values in array fields
+         * Sometimes the deep copy will add a duplicate value in array fields for seemingly no reason..
+         */
+        if (Array.isArray(val)) { 
+          const repSet = new Set(replacement[entry]);
+
+          replacement[entry] = Array.from(repSet);
+        } else {
+          Object.entries(val).forEach(([key, value]) => {
+            if (replacement[entry][key] === undefined) {
+              replacement[entry][key] = value;
+            }
+          })
+        }
       }
     })
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #164 

### Give a longer description of what this PR addresses and why it's needed
Added better error handling for importing state. Checks for duplicate values, mismatched dataset, and empty object fields. When the user imports a state with missing fields, a warning is shown by the "Load Data" button.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/c1be9f55-5387-4194-ae6a-d8e34af706ae)

![image](https://github.com/visdesignlab/upset2/assets/35744963/0fa5e52d-f988-4132-b45a-6e3c61cb7594)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...