### PR TITLE
fix: 🐛 Nested set-membership aggregates collapse

### DIFF
--- a/packages/upset/src/components/MatrixRows.tsx
+++ b/packages/upset/src/components/MatrixRows.tsx
@@ -55,10 +55,17 @@ export const MatrixRows: FC<Props> = ({ rows }) => {
 
   const rowTransitions = useTransition(
     rows.map(({ row, id }, index) => {
-      if (index > 0) { // account for double height "set" aggregate rows by doubling height AFTER the aggregate row is rendered
+      // account for double height "set" aggregate rows by doubling height AFTER the aggregate row is rendered
+      if (index > 0) {
         const prevRow = rows[index - 1].row;
-        if (isRowAggregate(prevRow) && ['Sets', 'Overlaps'].includes(prevRow.aggregateBy)) {
-          yTransform += dimensions.body.rowHeight;
+        /* 
+         * Only add an extra rowHeight to the transform if the previous row is 
+         * an aggregate containing set membership circles which is NOT contained in a collapsed parent aggregate
+         */
+        if (isRowAggregate(prevRow)   
+          && !(prevRow.parent && collapsedIds.includes(prevRow.parent))
+          && ['Sets', 'Overlaps'].includes(prevRow.aggregateBy)) {
+            yTransform += dimensions.body.rowHeight;
         }
       }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #177 

### Give a longer description of what this PR addresses and why it's needed
This fixes first level aggregates not collapsing properly when the nested aggregate is "sets" or "overlap".

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/0522eb5e-ce28-464d-98fe-4d9622af252e)

### Are there any additional TODOs before this PR is ready to go?
None