### PR TITLE
style: 💄 Add membership circle outline and reduced "may" radius

### DIFF
--- a/packages/upset/src/components/Matrix.tsx
+++ b/packages/upset/src/components/Matrix.tsx
@@ -1,4 +1,4 @@
-import { Aggregate, Subset } from '@visdesignlab/upset2-core';
+import { Aggregate, Subset, isRowAggregate } from '@visdesignlab/upset2-core';
 import React, { FC } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -51,6 +51,7 @@ export const Matrix: FC<Props> = ({
               onMouseLeave={() => {
                 setHoveredColumn(null);
               }}
+              showOutline={isRowAggregate(subset)}
             />
           );
         })}

--- a/packages/upset/src/components/custom/MembershipCircle.tsx
+++ b/packages/upset/src/components/custom/MembershipCircle.tsx
@@ -7,6 +7,7 @@ import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 
 type Props = SVGProps<SVGCircleElement> & {
   membershipStatus: SetMembershipStatus;
+  showOutline?: boolean
 };
 
 const MemberShipCircle: FC<Props> = (props) => {
@@ -15,15 +16,31 @@ const MemberShipCircle: FC<Props> = (props) => {
   const dimensions = useRecoilValue(dimensionsSelector);
 
   return (
-    <circle
-      {...base}
-      fill={
-        membershipStatus === 'No'
-          ? theme.matrix.member.no
-          : theme.matrix.member.yes
+    <>
+      <circle
+        {...base}
+        stroke={
+          props.showOutline && membershipStatus === 'No' 
+            ? theme.matrix.member.yes 
+            : theme.matrix.member.no
+        }
+        fill={
+          ['No', 'May'].includes(membershipStatus)
+            ? theme.matrix.member.no
+            : theme.matrix.member.yes
+        }
+        r={(dimensions.set.width - 5) / 2}
+      />
+      { membershipStatus === 'May' &&
+        <circle
+          {...base}
+          fill={
+            theme.matrix.member.yes
+          }
+          r={3}
+        />
       }
-      r={membershipStatus === 'May' ? '4' : (dimensions.set.width - 5) / 2}
-    />
+  </>
   );
 };
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #174 

### Give a longer description of what this PR addresses and why it's needed
Adds membership circle outlines by adding a background circle with or without outline. The smaller "may" circle is rendered as an additional circle on top of the background.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/65c60e10-bfc4-4e5b-ac9b-e7721cf96a7c)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...