### PR TITLE
style: 💄 font weight consistency

### DIFF
--- a/packages/upset/src/components/AggregateRow.tsx
+++ b/packages/upset/src/components/AggregateRow.tsx
@@ -95,6 +95,7 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
         <text
           css={css`
             font-size: 14px;
+            font-weight: 450;
           `}
           transform={translate(20, dimensions.body.rowHeight / 2)}
           dominantBaseline="middle"

--- a/packages/upset/src/components/custom/SetLabel.tsx
+++ b/packages/upset/src/components/custom/SetLabel.tsx
@@ -46,7 +46,7 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
             font-size: 14px;
             overflow: hidden;
             text-overflow: ellipsis; 
-            font-weight: bold;
+            font-weight: 500;
             height: 100%;
           `}>{name}</p>
         </foreignObject>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #182 

### Give a longer description of what this PR addresses and why it's needed
Font weight for visible sets label reduced to 500.
Aggregate row label font weight increased to 450.

The larger font size of the aggregate row label means that a slightly lower font weight matches visually.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/68a0f3d7-1fe2-465a-a1b4-e55040b4b105)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...