### PR TITLE
style: 💄 Adjust cardinality header to match attributes

### DIFF
--- a/packages/upset/src/components/Header/AttributeButton.tsx
+++ b/packages/upset/src/components/Header/AttributeButton.tsx
@@ -76,6 +76,7 @@ export const AttributeButton: FC<Props> = ({ label, sort = false }) => {
           e.preventDefault();
           openContextMenu(e);
       }}
+      transform={translate(0, 6)}
     >
       <rect
         height={dimensions.attribute.buttonHeight}

--- a/packages/upset/src/components/Header/CardinalityHeader.tsx
+++ b/packages/upset/src/components/Header/CardinalityHeader.tsx
@@ -269,6 +269,7 @@ export const CardinalityHeader: FC = () => {
         )}
       >
         <Axis
+          transform={translate(0, -8)}
           scale={detailScale}
           fontSize={0.8}
           type="bottom"
@@ -278,7 +279,7 @@ export const CardinalityHeader: FC = () => {
           hideLine
         />
         <Axis
-          transform={translate(0, dimensions.cardinality.scaleHeight)}
+          transform={translate(0, dimensions.cardinality.scaleHeight - 4)}
           scale={detailScale}
           type="top"
           margin={0}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #181 

### Give a longer description of what this PR addresses and why it's needed
This PR fixes the cardinality header button and axes being misaligned with the attributes.

To do this, the cardinality bottom axis spacing has been adjusted and the y-transform of the other attribute buttons has been adjusted to match the existing cardinality positioning. This is to allow space for a horizontal scroll bar under hidden sets + advanced scale.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/ee7b30c5-971e-42df-b416-5ad76b548cae)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...