### PR TITLE
Set matrix tooltips

### DIFF
--- a/packages/upset/src/components/Matrix.tsx
+++ b/packages/upset/src/components/Matrix.tsx
@@ -78,7 +78,7 @@ export const Matrix: FC<Props> = ({
                 cx={idx * dimensions.set.width}
                 cy={dimensions.body.rowHeight / 2}
                 pointerEvents="all"
-                showoutline={isRowAggregate(subset) ? true : undefined}
+                showoutline={isRowAggregate(subset)}
               />
             </Group>
           );

--- a/packages/upset/src/components/Matrix.tsx
+++ b/packages/upset/src/components/Matrix.tsx
@@ -9,6 +9,7 @@ import Group from './custom/Group';
 import MemberShipCircle from './custom/MembershipCircle';
 import { defaultBackground, hoverHighlight } from '../utils/styles';
 import translate from '../utils/transform';
+import { setsAtom } from '../atoms/setsAtoms';
 
 type Props = {
   subset: Subset | Aggregate;
@@ -22,6 +23,7 @@ export const Matrix: FC<Props> = ({
   sets = [],
 }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
+  const setList = useRecoilValue(setsAtom);
   const [ columnHover, setColumnHover ] = useRecoilState(columnHoverAtom);
   const [ columnSelect, setColumnSelect ] = useRecoilState(columnSelectAtom);
 
@@ -56,6 +58,9 @@ export const Matrix: FC<Props> = ({
                 }
               }}
             >
+              <title>
+                {setList[set].elementName}
+              </title>
               <rect 
                 transform={translate(idx * dimensions.set.width - dimensions.set.width/2, 0)} 
                 height={dimensions.body.rowHeight} 

--- a/packages/upset/src/components/custom/MembershipCircle.tsx
+++ b/packages/upset/src/components/custom/MembershipCircle.tsx
@@ -7,11 +7,11 @@ import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 
 type Props = SVGProps<SVGCircleElement> & {
   membershipStatus: SetMembershipStatus;
-  showoutline?: boolean
+  showoutline: boolean;
 };
 
 const MemberShipCircle: FC<Props> = (props) => {
-  const { membershipStatus, ...base } = props;
+  const { membershipStatus, showoutline, ...base } = props;
   const theme = useTheme();
   const dimensions = useRecoilValue(dimensionsSelector);
 
@@ -20,7 +20,7 @@ const MemberShipCircle: FC<Props> = (props) => {
       <circle
         {...base}
         stroke={
-          props.showoutline && membershipStatus === 'No' 
+          showoutline && membershipStatus === 'No' 
             ? theme.matrix.member.yes 
             : theme.matrix.member.no
         }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #180 

### Give a longer description of what this PR addresses and why it's needed
This adds a title tooltip to every matrix membership circle. The tooltip is the native SVG title element with the set name.

Also, the pr changes the "showoutline" attribute of membership circle to fix an error when aggregating by set or overlap.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...