### PR TITLE
feat: 🎸 Accessible data-table

### DIFF
--- a/packages/app/src/components/DataTable.tsx
+++ b/packages/app/src/components/DataTable.tsx
@@ -1,0 +1,77 @@
+import { Button, Dialog } from "@mui/material"
+import { useRecoilValue } from "recoil";
+import { dataSelector } from "../atoms/dataAtom";
+import { Row, getRows, isRowAggregate } from "@visdesignlab/upset2-core";
+import { useContext, useMemo } from "react";
+import { ProvenanceContext } from "./Root";
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+
+const getRowData = (row: Row) => {
+    return {id: row.id, elementName: `${(isRowAggregate(row)) ? "Aggregate: " : ""}${row.elementName}`, cardinality: row.size}
+}
+
+export const DataTable = (props: {close: () => void}) => {
+    const { provenance } = useContext(ProvenanceContext);
+
+    const data = useRecoilValue(dataSelector);
+    const processedRows = getRows(data, provenance.getState());
+    
+    // fetch subset data and create row objects with subset name and cardinality
+    const tableRows: ReturnType<typeof getRowData>[] = useMemo(() => {
+        const retVal: ReturnType<typeof getRowData>[] = [];
+        
+        Object.values(processedRows.values).forEach((r: Row) => {
+            retVal.push(getRowData(r));
+            if (isRowAggregate(r)) {
+                Object.values(r.items.values).forEach((row: Row) => {
+                    retVal.push(getRowData(row));
+                });
+            }
+        });
+
+        return retVal;
+    
+    }, [processedRows]);
+
+    const columns: GridColDef[] = [
+        {
+          field: 'elementName',
+          headerName: 'Subset',
+          width: 250,
+          editable: false,
+        },
+        {
+          field: 'cardinality',
+          headerName: 'Cardinality',
+          width: 250,
+          editable: false,
+        },
+    ]
+
+    return (
+        <Dialog
+            open={true}
+            onClose={props.close}
+            fullWidth
+            sx={{height: "100%", width: "100%"}}
+        >
+            <DataGrid
+                columns={columns}
+                rows={tableRows}
+                autoHeight
+                disableSelectionOnClick
+                initialState={{
+                    pagination: {
+                        page: 0,
+                        pageSize: 5,
+                    },
+                  }}
+                paginationMode="client"
+                rowsPerPageOptions={[5]}
+            ></DataGrid>
+            <div style={{display: "flex", justifyContent: "flex-end", margin: "10px"}}>
+                <Button color="inherit" size="medium" variant="outlined" onClick={props.close}>Close</Button>
+            </div>
+        </Dialog>
+    )   
+}

--- a/packages/app/src/components/DataTable.tsx
+++ b/packages/app/src/components/DataTable.tsx
@@ -63,11 +63,11 @@ export const DataTable = (props: {close: () => void}) => {
                 initialState={{
                     pagination: {
                         page: 0,
-                        pageSize: 5,
+                        pageSize: 10,
                     },
                   }}
                 paginationMode="client"
-                rowsPerPageOptions={[5]}
+                rowsPerPageOptions={[5, 10, 20]}
             ></DataGrid>
             <div style={{display: "flex", justifyContent: "flex-end", margin: "10px"}}>
                 <Button color="inherit" size="medium" variant="outlined" onClick={props.close}>Close</Button>

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -82,12 +82,14 @@ const Header = ({ data }: { data: any }) => {
           </ButtonGroup>
         </Box>
         <Box sx={{display:'flex', alignItems: 'center', margin: 0, padding: 0}}>
-          <Button
-            color="inherit"
-            onClick={(e) => {handleDataTableClick(e)}}
-          >
-            Data Table
-          </Button>
+          {data !== null &&
+            <Button
+              color="inherit"
+              onClick={(e) => {handleDataTableClick(e)}}
+            >
+              Data Table
+            </Button>
+          }
           {showDataTable && 
             <DataTable close={handleDataTableClose}></DataTable>
           }

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -16,6 +16,7 @@ import { ProvenanceContext } from '../Root';
 import { ImportModal } from '../ImportModal';
 import { AttributeDropdown } from '../AttributeDropdown';
 import { importErrorAtom } from '../../atoms/importErrorAtom';
+import { DataTable } from '../DataTable';
 
 const Header = ({ data }: { data: any }) => {
   const { workspace } = useRecoilValue(queryParamAtom);
@@ -27,6 +28,7 @@ const Header = ({ data }: { data: any }) => {
 
   const [ attributeDialog, setAttributeDialog ] = useState(false);
   const [ showImportModal, setShowImportModal ] = useState(false);
+  const [ showDataTable, setShowDataTable ] = useState(false);
   const [ isMenuOpen, setIsMenuOpen ] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
 
@@ -49,6 +51,12 @@ const Header = ({ data }: { data: any }) => {
   const handleAttributeClose = () => {
     setAnchorEl(null);
     setAttributeDialog(false);
+  }
+  const handleDataTableClick = (event: React.MouseEvent<any>) => {
+    setShowDataTable(true);
+  }
+  const handleDataTableClose = () => {
+    setShowDataTable(false);
   }
   
   return (
@@ -76,7 +84,16 @@ const Header = ({ data }: { data: any }) => {
         <Box sx={{display:'flex', alignItems: 'center', margin: 0, padding: 0}}>
           <Button
             color="inherit"
-            onClick={(event) => { handleAttributeClick(event) }}
+            onClick={(e) => {handleDataTableClick(e)}}
+          >
+            Data Table
+          </Button>
+          {showDataTable && 
+            <DataTable close={handleDataTableClose}></DataTable>
+          }
+          <Button
+            color="inherit"
+            onClick={(e) => { handleAttributeClick(e) }}
           >
             Attributes
           </Button>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #200 

### Give a longer description of what this PR addresses and why it's needed
This adds the data table for the subset data. This table uses MUI `DataGrid` (MIT License). The table is keyboard navigable and I tested it with the Mac VoiceOver and it seems usable (although I have VERY limited experience with screen readers).

Note that this component is within the `app` package and the button to open the data table is easily accessible via the toolbar.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/f0b86de5-b293-4a0d-bdbc-d635f8973638)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] basic screen reader test