### PR TITLE
Update drawer css

### DIFF
--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -113,10 +113,10 @@ export const ElementSidebar = ({ open, close }: Props) => {
         flexShrink: 0,
         '& .MuiDrawer-paper': {
           padding: '1em',
+          marginTop: '2em',
           width: hideElementSidebar ? 0 : fullWidth ? '100%' : drawerWidth,
           boxSizing: 'border-box',
-          position: 'inherit',
-          zIndex: -1,
+          zIndex: 0,
         },
       }}
       open={open}

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -32,10 +32,10 @@ export const ProvenanceVis = ({ open, close }: Props) => {
         flexShrink: 0,
         '& .MuiDrawer-paper': {
           padding: '1em',
+          marginTop: '2em',
           width: (open) ? initialDrawerWidth : 0,
           boxSizing: 'border-box',
-          position: 'inherit',
-          zIndex: -1,
+          zIndex: 0,
         },
       }}
     >


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
For whatever reason, the CSS for the drawers (element sidebar and history) was no longer working as intended. I believe this has something to do with `position: inherit` pulling a bad value. By removing this and adding `z-index: 0`, the drawers work as intended.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...