### PR TITLE
feat: 🎸 Upset plot SVG download

### DIFF
--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { exportState, getAccessibleData } from '@visdesignlab/upset2-react';
+import { exportState, getAccessibleData, downloadSVG } from '@visdesignlab/upset2-react';
 import { getRows } from '@visdesignlab/upset2-core';
 import { UserSpec } from 'multinet';
 import RedoIcon from '@mui/icons-material/Redo';
@@ -199,6 +199,9 @@ const Header = ({ data }: { data: any }) => {
               </MenuItem>
               <MenuItem onClick={() => exportState(provenance, data, getRows(data, provenance.getState()))}>
                 Export State + Data
+              </MenuItem>
+              <MenuItem onClick={() => downloadSVG()}>
+                Download SVG
               </MenuItem>
               <MenuItem onClick={() => {
                   if (isElementSidebarOpen) {

--- a/packages/upset/src/components/AggregateRow.tsx
+++ b/packages/upset/src/components/AggregateRow.tsx
@@ -71,18 +71,18 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
       <g transform={translate(aggregateRow.level === 2 ? secondLevelXOffset : 2, 0)}>
         <rect
           transform={translate(0, 2)}
-          css={currentIntersection !== null && currentIntersection.id === aggregateRow.id ?
-            highlight :
-            css`
-            fill: #cccccc;
-            opacity: 0.3;
-            stroke: #555555;
-            stroke-width: 1px;
-          `}
+          css={
+            (currentIntersection !== null && currentIntersection.id === aggregateRow.id) &&
+              highlight
+          }
           height={(['Sets', 'Overlaps'].includes(aggregateRow.aggregateBy)) ? (dimensions.body.rowHeight - 4) * 2 : dimensions.body.rowHeight - 4}
           width={width}
           rx={5}
           ry={10}
+          fill="#cccccc"
+          opacity="0.3"
+          stroke="#555555"
+          strokeWidth="1px"
         />
         <g
           onClick={() => {

--- a/packages/upset/src/components/DeviationBar.tsx
+++ b/packages/upset/src/components/DeviationBar.tsx
@@ -11,12 +11,9 @@ type Props = {
   deviation: number;
 };
 
-const negativeDeviation = css`
-  fill: #f46d43;
-`;
-const positiveDeviation = css`
-  fill: #74add1;
-`;
+const negativeDeviation = '#f46d43';
+
+const positiveDeviation = '#74add1';
 
 export const DeviationBar: FC<Props> = ({ deviation }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
@@ -38,9 +35,7 @@ export const DeviationBar: FC<Props> = ({ deviation }) => {
       )}
     >
       <rect
-        css={css`
-          ${deviation > 0 ? positiveDeviation : negativeDeviation}
-        `}
+        fill={(deviation > 0) ? positiveDeviation : negativeDeviation}
         transform={translate(
           deviation > 0 ? 0 : -deviationScale(Math.abs(deviation)),
           0,

--- a/packages/upset/src/components/Header/AttributeButton.tsx
+++ b/packages/upset/src/components/Header/AttributeButton.tsx
@@ -82,12 +82,10 @@ export const AttributeButton: FC<Props> = ({ label, sort = false }) => {
       <rect
         height={dimensions.attribute.buttonHeight}
         width={dimensions.attribute.width}
-        css={{
-          fill: '#ccc',
-          stroke: 'black',
-          opacity: 0.5,
-          strokeWidth: '0.3px',
-        }}
+        fill="#ccc"
+        stroke="#000"
+        opacity="0.5"
+        strokeWidth="0.3px"
       />
       <text
         pointerEvents={sort ? 'default' : 'none'}

--- a/packages/upset/src/components/Header/CollapseAllButton.tsx
+++ b/packages/upset/src/components/Header/CollapseAllButton.tsx
@@ -12,9 +12,7 @@ import { dataAtom } from '../../atoms/dataAtom';
 
 const iconSize = 16;
 
-const hidden = css`
-    display: none;
-`;
+const hidden = 'none';
 
 const collapseAllStyle = css`
     cursor: pointer;
@@ -56,7 +54,7 @@ export const CollapseAllButton = () => {
   };
 
   return (
-    <Group tx={iconSize + 5} ty={dimensions.header.totalHeight - iconSize} css={firstAggregateBy === 'None' && hidden}>
+    <Group tx={iconSize + 5} ty={dimensions.header.totalHeight - iconSize} style={{ display: (firstAggregateBy === 'None') ? hidden : 'inherit' }}>
       <Tooltip title={`${allCollapsed ? 'Expand All' : 'Collapse All'}`}>
         <g>
           <rect height={iconSize} width={iconSize} css={collapseAllStyle} onClick={toggleCollapseAll} opacity={0} />

--- a/packages/upset/src/components/Header/MatrixHeader.tsx
+++ b/packages/upset/src/components/Header/MatrixHeader.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useRecoilValue } from 'recoil';
 
-import { css } from '@emotion/react';
 import { hiddenSetSelector, visibleSetSelector } from '../../atoms/config/visibleSetsAtoms';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 import { maxSetSizeSelector } from '../../atoms/maxSetSizeSelector';
@@ -24,25 +23,25 @@ export const MatrixHeader = () => {
     <>
       <SetHeader visibleSets={visibleSets} scale={scale} />
       <foreignObject
-        transform={translate(dimensions.matrixColumn.width +
-        dimensions.bookmarkStar.gap +
-        dimensions.bookmarkStar.width +
-        dimensions.bookmarkStar.gap, 0)}
-        css={css`
-        width: ${
+        width={
           dimensions.size.width +
           dimensions.gap +
-          dimensions.attribute.width}px;
-        height: ${dimensions.set.size.height + 15}px;
-      `}
+          dimensions.attribute.width
+        }
+        height={dimensions.set.size.height + 15}
       >
         <div
           id="hiddenSetDiv"
-          css={css`
-          overflow-x: auto;
-          overflow-y: hidden;
-          height: 100%;
-        `}
+          style={{
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            position: 'absolute',
+            left: dimensions.matrixColumn.width +
+                  dimensions.bookmarkStar.gap +
+                  dimensions.bookmarkStar.width +
+                  dimensions.bookmarkStar.gap,
+            height: '100%',
+          }}
         >
           <svg width={hiddenSets.length * (set.width + 1)}>
             <HiddenSets hiddenSets={hiddenSets} scale={scale} />

--- a/packages/upset/src/components/Header/MatrixHeader.tsx
+++ b/packages/upset/src/components/Header/MatrixHeader.tsx
@@ -29,24 +29,25 @@ export const MatrixHeader = () => {
           dimensions.attribute.width
         }
         height={dimensions.set.size.height + 15}
+        transform={translate(dimensions.matrixColumn.width +
+                dimensions.bookmarkStar.gap +
+                dimensions.bookmarkStar.width +
+                dimensions.bookmarkStar.gap, 0)}
       >
-        <div
-          id="hiddenSetDiv"
-          style={{
-            overflowX: 'auto',
-            overflowY: 'hidden',
-            position: 'absolute',
-            left: dimensions.matrixColumn.width +
-                  dimensions.bookmarkStar.gap +
-                  dimensions.bookmarkStar.width +
-                  dimensions.bookmarkStar.gap,
-            height: '100%',
-          }}
-        >
-          <svg width={hiddenSets.length * (set.width + 1)}>
-            <HiddenSets hiddenSets={hiddenSets} scale={scale} />
-          </svg>
-        </div>
+        <body xmlns="http://www.w3.org/2000/xhtml" padding="0" margin="0" style={{ fontFamily: 'Roboto, Arial' }}>
+          <div
+            id="hiddenSetDiv"
+            style={{
+              overflowX: 'auto',
+              overflowY: 'hidden',
+              height: '100%',
+            }}
+          >
+            <svg width={hiddenSets.length * (set.width + 1)} xmlns="http://www.w3.org/2000/svg">
+              <HiddenSets hiddenSets={hiddenSets} scale={scale} />
+            </svg>
+          </div>
+        </body>
       </foreignObject>
     </>
   );

--- a/packages/upset/src/components/Header/SetHeader.tsx
+++ b/packages/upset/src/components/Header/SetHeader.tsx
@@ -13,7 +13,7 @@ import { ProvenanceContext } from '../Root';
 import { contextMenuAtom } from '../../atoms/contextMenuAtom';
 import { visibleSortSelector } from '../../atoms/config/visibleSetsAtoms';
 import translate from '../../utils/transform';
-import { columnHoverAtom } from '../../atoms/highlightAtom';
+import { columnHoverAtom, columnSelectAtom } from '../../atoms/highlightAtom';
 
 type Props = {
   visibleSets: string[];
@@ -26,6 +26,7 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
   const sortVisibleBy = useRecoilValue(visibleSortSelector);
 
   const setColumnHover = useSetRecoilState(columnHoverAtom);
+  const setColumnSelect = useSetRecoilState(columnSelectAtom);
 
   const { actions } = useContext(
     ProvenanceContext,
@@ -104,6 +105,10 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
           css={css`cursor: context-menu;`}
           onMouseEnter={() => setColumnHover([set.setName])}
           onMouseLeave={() => setColumnHover([])}
+          onClick={(e) => {
+            e.stopPropagation();
+            setColumnSelect([set.setName]);
+          }}
         >
           <SetSizeBar
             scale={scale}

--- a/packages/upset/src/components/Header/SizeHeader.tsx
+++ b/packages/upset/src/components/Header/SizeHeader.tsx
@@ -165,11 +165,9 @@ export const SizeHeader: FC = () => {
         <rect
           height={dimensions.size.scaleHeight}
           width={globalScale(maxC)}
-          css={css`
-            fill: #aaa;
-            opacity: 0.2;
-            pointer-events: none;
-          `}
+          fill="#aaa"
+          opacity="0.2"
+          pointerEvents="none"
           stroke="none"
         />
         <g
@@ -181,14 +179,12 @@ export const SizeHeader: FC = () => {
         >
           <rect
             ref={sliderRef}
-            css={css`
-              fill: #ccc;
-              opacity: 0.5;
-              pointer-events: all;
-              cursor: col-resize;
-              stroke: black;
-              stroke-width: 1px;
-            `}
+            fill="#ccc"
+            opacity="0.5"
+            pointerEvents="all"
+            cursor="col-resize"
+            stroke="black"
+            strokeWidth="1px"
             transform="rotate(45)"
             height="10"
             width="10"
@@ -197,13 +193,10 @@ export const SizeHeader: FC = () => {
       </g>}
       <g
         className="sliderInfluence"
-        css={css`
-          ${!sliding ? hide : show}
-        `}
         transform={translate(0, dimensions.size.scaleHeight)}
       >
         <path
-          opacity="0.3"
+          opacity={(!sliding) ? 0.0 : 0.3}
           fill="#ccc"
           d={`M ${globalScale(maxC)} 0 H 0 V ${dimensions.size
             .buttonHeight +
@@ -231,12 +224,10 @@ export const SizeHeader: FC = () => {
         }}
       >
         <rect
-          css={css`
-            fill: #ccc;
-            stroke: black;
-            opacity: 0.5;
-            stroke-width: 0.3px;
-          `}
+          fill="#ccc"
+          stroke="#000"
+          opacity="0.5"
+          strokeWidth="0.3px"
           height={dimensions.size.buttonHeight}
           width={dimensions.attribute.width}
           onClick={() => {

--- a/packages/upset/src/components/Matrix.tsx
+++ b/packages/upset/src/components/Matrix.tsx
@@ -71,6 +71,7 @@ export const Matrix: FC<Props> = ({
                     ? hoverHighlight
                     : defaultBackground
                 }
+                fillOpacity="0.0"
               />
               <MemberShipCircle
                 membershipStatus={membershipStatus}
@@ -78,6 +79,7 @@ export const Matrix: FC<Props> = ({
                 cy={dimensions.body.rowHeight / 2}
                 pointerEvents="all"
                 showoutline={isRowAggregate(subset)}
+                fillOpacity="1.0"
               />
             </Group>
           );
@@ -88,6 +90,7 @@ export const Matrix: FC<Props> = ({
             x2={lastMember * dimensions.set.width}
             y1={dimensions.body.rowHeight / 2}
             y2={dimensions.body.rowHeight / 2}
+            fillOpacity="0.0"
           />
         )}
       </Group>

--- a/packages/upset/src/components/SizeBar.tsx
+++ b/packages/upset/src/components/SizeBar.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { Row } from '@visdesignlab/upset2-core';
 import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -15,29 +14,12 @@ type Props = {
   row?: Row;
 };
 
-const color1 = css`
-  fill: rgb(189, 189, 189);
-`;
-
-const color2 = css`
-  fill: rgb(136, 136, 136);
-`;
-
-const color3 = css`
-  fill: rgb(37, 37, 37);
-`;
-
-const color4 = css`
-  fill: rgb(116, 173, 209);
-`;
-
-const color5 = css`
-  fill: rgb(94, 102, 171);
-`;
-
-const color6 = css`
-  fill: rgb(29, 41, 71);
-`;
+const color1 = 'rgb(189, 189, 189)';
+const color2 = 'rgb(136, 136, 136)';
+const color3 = 'rgb(37, 37, 37)';
+const color4 = 'rgb(116, 173, 209)';
+const color5 = 'rgb(94, 102, 171)';
+const color6 = 'rgb(29, 41, 71)';
 
 export const SizeBar: FC<Props> = ({ row, size }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
@@ -85,7 +67,7 @@ export const SizeBar: FC<Props> = ({ row, size }) => {
           key={arr}
           height={dimensions.size.plotHeight - arr * offset}
           width={dimensions.attribute.width}
-          css={row !== undefined && currentIntersection !== null && currentIntersection.id === row.id ? colors[arr + highlightOffset] : colors[arr]}
+          fill={row !== undefined && currentIntersection !== null && currentIntersection.id === row.id ? colors[arr + highlightOffset] : colors[arr]}
         />
       ))}
       {fullBars < 3 && (
@@ -93,7 +75,7 @@ export const SizeBar: FC<Props> = ({ row, size }) => {
           transform={translate(0, (fullBars * offset) / 2)}
           height={dimensions.size.plotHeight - fullBars * offset}
           width={scale(rem)}
-          css={row !== undefined && currentIntersection !== null && currentIntersection.id === row.id ? colors[fullBars + highlightOffset] : colors[fullBars]}
+          fill={row !== undefined && currentIntersection !== null && currentIntersection.id === row.id ? colors[fullBars + highlightOffset] : colors[fullBars]}
         />
       )}
       {fullBars === 3 && (

--- a/packages/upset/src/components/SubsetRow.tsx
+++ b/packages/upset/src/components/SubsetRow.tsx
@@ -67,6 +67,7 @@ export const SubsetRow: FC<Props> = ({ subset }) => {
         }
         rx="5"
         ry="10"
+        fillOpacity="0.0"
       />
       <Matrix sets={visibleSets} subset={subset} />
       {bookmarkedIntersections.find((b) => b.id === subset.id) &&

--- a/packages/upset/src/components/SvgBase.tsx
+++ b/packages/upset/src/components/SvgBase.tsx
@@ -33,7 +33,7 @@ export const SvgBase: FC<Props> = ({ children, defaultSettings }) => {
         }
       `}
     >
-      <svg height={height + 50 * margin} width={width + 2 * margin}>
+      <svg id="upset-svg" height={height + 50 * margin} width={width + 2 * margin}>
         <g transform={translate(margin)}>
           <rect
             height={height}

--- a/packages/upset/src/components/SvgBase.tsx
+++ b/packages/upset/src/components/SvgBase.tsx
@@ -33,7 +33,7 @@ export const SvgBase: FC<Props> = ({ children, defaultSettings }) => {
         }
       `}
     >
-      <svg id="upset-svg" height={height + 50 * margin} width={width + 2 * margin}>
+      <svg id="upset-svg" height={height + 50 * margin} width={width + 2 * margin} xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="full" fontFamily="Roboto, Arial">
         <g transform={translate(margin)}>
           <rect
             height={height}

--- a/packages/upset/src/components/custom/SetLabel.tsx
+++ b/packages/upset/src/components/custom/SetLabel.tsx
@@ -30,12 +30,13 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
       <rect
         className={setId}
         css={
-          columnHover.includes(setId) || columnSelect.includes(setId)
-            ? hoverHighlight
-            : matrixColumnBackgroundRect
+          (columnHover.includes(setId) || columnSelect.includes(setId)) &&
+            hoverHighlight
         }
         height={dimensions.set.label.height - gap}
         width={dimensions.set.width - gap / 2}
+        fill="#f0f0f0"
+        fillOpacity="1.0"
         transform={`${translate(
           gap / 4,
           gap,
@@ -47,16 +48,17 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
         width={dimensions.set.label.height}
         z={100}
       >
-        <p css={css`
-            color: #000000; 
-            font-size: 14px;
-            overflow: hidden;
-            text-overflow: ellipsis; 
-            font-weight: 500;
-            height: 100%;
-            padding: 0;
-            margin: 2px 0 0 0;
-          `}
+        <p style={{
+          color: '#000000',
+          fontSize: '14px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          fontWeight: '500',
+          height: '100%',
+          padding: '0',
+          margin: '2px 0 0 0',
+          textAlign: 'start',
+        }}
         >
           {name}
         </p>

--- a/packages/upset/src/components/custom/SetLabel.tsx
+++ b/packages/upset/src/components/custom/SetLabel.tsx
@@ -47,21 +47,25 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
         height={dimensions.set.width}
         width={dimensions.set.label.height}
         z={100}
-      >
-        <p style={{
+        style={{
           color: '#000000',
           fontSize: '14px',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
-          fontWeight: '500',
-          height: '100%',
-          padding: '0',
-          margin: '2px 0 0 0',
-          textAlign: 'start',
         }}
-        >
-          {name}
-        </p>
+
+      >
+        <body xmlns="http://www.w3.org/2000/xhtml" padding="0" margin="0" style={{ fontFamily: 'Roboto, Arial' }}>
+          <p style={{
+            height: '100%',
+            padding: '0',
+            margin: '2px 0 0 0',
+            fontWeight: '500',
+            textAlign: 'start',
+          }}>
+            {name}
+          </p>
+        </body>
       </foreignObject>
     </Group>
   );

--- a/packages/upset/src/components/custom/SetSizeBar.tsx
+++ b/packages/upset/src/components/custom/SetSizeBar.tsx
@@ -75,19 +75,23 @@ export const SetSizeBar: FC<Props> = ({
           height={dimensions.set.width}
           width={dimensions.set.label.height - (dimensions.set.width / 2)}
           z={100}
-        >
-          <p style={{
+          style={{
             color: '#000000',
             fontSize: '14px',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            padding: '0',
-            margin: '0',
             textAlign: 'start',
           }}
-          >
-            {label}
-          </p>
+        >
+          <body xmlns="http://www.w3.org/2000/xhtml" padding="0" margin="0" style={{ fontFamily: 'Roboto, Arial' }}>
+            <p style={{
+              padding: '0',
+              margin: '0',
+            }}
+            >
+              {label}
+            </p>
+          </body>
         </foreignObject>
       )}
     </Group>

--- a/packages/upset/src/components/custom/SetSizeBar.tsx
+++ b/packages/upset/src/components/custom/SetSizeBar.tsx
@@ -9,16 +9,6 @@ import Group from './Group';
 import { columnHoverAtom, columnSelectAtom } from '../../atoms/highlightAtom';
 import { hoverHighlight } from '../../utils/styles';
 
-/** @jsxImportSource @emotion/react */
-const matrixColumnBackgroundRect = css`
-  fill: #f0f0f0;
-`;
-const matrixColumnForegroundRect = css`
-  fill: #636363;
-  stroke: #fff;
-  stroke-width: 1px;
-`;
-
 type Props = {
   scale: ScaleLinear<number, number>;
   setId: string;
@@ -58,23 +48,21 @@ export const SetSizeBar: FC<Props> = ({
 
       <rect
         css={
-          columnHover.includes(setId) || columnSelect.includes(setId)
-            ? hoverHighlight
-            : matrixColumnBackgroundRect
+          (columnHover.includes(setId) || columnSelect.includes(setId)) &&
+            hoverHighlight
         }
         height={dimensions.set.size.height}
         width={dimensions.set.width}
         stroke="none"
-        fill="gray"
+        fill="#f0f0f0"
+        fillOpacity={1.0}
       />
       <rect
-        css={css`
-          ${matrixColumnForegroundRect}
-        `}
+        fill="#636363"
+        stroke="#fff"
+        strokeWidth="1px"
         height={scale(size)}
         width={dimensions.set.width}
-        stroke="none"
-        fill="gray"
         opacity={foregroundOpacity}
         transform={translate(
           0,
@@ -88,14 +76,15 @@ export const SetSizeBar: FC<Props> = ({
           width={dimensions.set.label.height - (dimensions.set.width / 2)}
           z={100}
         >
-          <p css={css`
-            color: #000000; 
-            font-size: 14px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            padding: 0;
-            margin: 0; 
-          `}
+          <p style={{
+            color: '#000000',
+            fontSize: '14px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            padding: '0',
+            margin: '0',
+            textAlign: 'start',
+          }}
           >
             {label}
           </p>

--- a/packages/upset/src/index.tsx
+++ b/packages/upset/src/index.tsx
@@ -8,6 +8,11 @@ export {
   initializeProvenanceTracking,
 } from './provenance';
 
-export { upsetConfigAtom, defaultConfig } from './atoms/config/upsetConfigAtoms';
+export {
+  upsetConfigAtom,
+  defaultConfig,
+} from './atoms/config/upsetConfigAtoms';
+
+export * from './utils/downloads';
 
 export * from './utils/exports';

--- a/packages/upset/src/utils/downloads.ts
+++ b/packages/upset/src/utils/downloads.ts
@@ -1,0 +1,21 @@
+export function downloadSVG(
+  filename = `upset-plot-${new Date().toJSON().slice(0, 10)}`,
+) {
+  const svg = document.getElementById('upset-svg');
+
+  if (!svg) {
+    // eslint-disable-next-line no-console
+    console.error("Couldn't find SVG element");
+    return;
+  }
+
+  const blob = new Blob([svg.outerHTML], { type: 'image/svg+xml' });
+  const href = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = href;
+  link.download = `${filename}.svg`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(href);
+}

--- a/packages/upset/src/utils/styles.ts
+++ b/packages/upset/src/utils/styles.ts
@@ -6,6 +6,7 @@ export const highlight = css`
   stroke: #feca82;
   stroke-width: 2;
   stroke-opacity: 0.8;
+  fill-opacity: 1.0;
 `;
 
 export const columnHighlight = css`


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #196 

### Give a longer description of what this PR addresses and why it's needed
Allows the user to download the UpSet plot as an SVG

### Provide pictures/videos of the behavior before and after these changes (optional)
![upset-plot-2023-08-21(42)](https://github.com/visdesignlab/upset2/assets/35744963/66e91003-4e42-4cc0-9b6c-1152241c1d2f)
This is the SVG export directly from Upset ^^^

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...