### PR TITLE
fix: 🐛 attribute NaN errors when loading encoded data

### DIFF
--- a/packages/app/src/components/ErrorModal.tsx
+++ b/packages/app/src/components/ErrorModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Dialog, DialogTitle, DialogContent, DialogContentText, FormControl, InputLabel, Checkbox, ListItemText, MenuItem, OutlinedInput, Select, SelectChangeEvent, Button } from "@mui/material"
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { dataSelector, encodedDataAtom } from "../atoms/dataAtom";
-import { CoreUpsetData, process } from "@visdesignlab/upset2-core";
+import { oneHotEncode } from "../utils/oneHotEncoding";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -33,39 +33,8 @@ export const ErrorModal = () => {
         setEncodeList(typeof value === 'string' ? value.split(',') : value)
     }
 
-    const oneHotEncode = (empty?: boolean) => {
-        const newColNames: string[] = []
-        const encodedData: CoreUpsetData = structuredClone(data);
-
-        // close the error window
-        if (empty) {
-            setEncodedDataAtom(encodedData);
-            return;
-        }
-
-        // get the unique names of every new column to be added. 
-        //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
-        encodeList.forEach((s) => Object.entries(data.items).forEach(([id, row]) => {
-            let names = `${row[s]}`.split(',');
-            names = names.filter((n) => n !== "")
-            newColNames.push(...names.map((val) => `${s}_${val}`))
-        }))
-        const uniqueColNames: Set<string> = new Set(newColNames);
-
-        // populate the data items group membership
-        Object.entries(encodedData.items).forEach(([id, row]) => {
-            Array.from(uniqueColNames).forEach((col) => {
-                let splitCol = col.split('_');
-                row[col] = `${row[splitCol[0]]}`.includes(splitCol[1])
-            })
-        })
-
-        // create the new annotations to pass into process, these are needed to ensure that the columns are added to columnTypes
-        const newAnnotations = Array.from(uniqueColNames).map((col) => {return {[col]: "boolean"}})
-            .reduce((obj, item) => Object.assign(obj, item), {})
-        const annotations = {...encodedData.columnTypes, ...newAnnotations}
-        
-        setEncodedDataAtom(process(Object.values(encodedData.items) as any, { columns: annotations } as any));
+    const handleSubmit = (empty = false) => {
+        setEncodedDataAtom(oneHotEncode(encodeList, data, empty));
     }
     
     return (
@@ -102,8 +71,8 @@ export const ErrorModal = () => {
                             </Select>
                         </FormControl>
 
-                        <Button style={{ height: "60%" }} color="error" onClick={() => { encodeList.length = 0; oneHotEncode(true) }}>Cancel</Button>
-                        <Button style={{ height: "60%" }} color="secondary" variant="contained" onClick={() => oneHotEncode()}>Submit</Button>
+                        <Button style={{ height: "60%" }} color="error" onClick={() => { encodeList.length = 0; handleSubmit(true) }}>Cancel</Button>
+                        <Button style={{ height: "60%" }} color="secondary" variant="contained" onClick={() => handleSubmit()}>Submit</Button>
                     </div>
                 </div>
                 }

--- a/packages/app/src/utils/oneHotEncoding.ts
+++ b/packages/app/src/utils/oneHotEncoding.ts
@@ -13,7 +13,7 @@ export const oneHotEncode = (encodeList: string[], data: CoreUpsetData, empty?: 
     //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
     encodeList.forEach((s) => Object.entries(data.items).forEach(([id, row]) => {
         const names = `${row[s]}`
-          .split(',');
+          .split(',')
           .filter((n) => n !== "")
           .map((val) => `${s}_${val}`);
         newColNames.push(...names)

--- a/packages/app/src/utils/oneHotEncoding.ts
+++ b/packages/app/src/utils/oneHotEncoding.ts
@@ -1,0 +1,35 @@
+import { CoreUpsetData, process } from "@visdesignlab/upset2-core";
+
+export const oneHotEncode = (encodeList: string[], data: CoreUpsetData, empty?: boolean) => {
+    const newColNames: string[] = []
+    const encodedData: CoreUpsetData = structuredClone(data);
+
+    // close the error window
+    if (empty) {
+        return encodedData;
+    }
+
+    // get the unique names of every new column to be added. 
+    //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
+    encodeList.forEach((s) => Object.entries(data.items).forEach(([id, row]) => {
+        let names = `${row[s]}`.split(',');
+        names = names.filter((n) => n !== "")
+        newColNames.push(...names.map((val) => `${s}_${val}`))
+    }))
+    const uniqueColNames: Set<string> = new Set(newColNames);
+
+    // populate the data items group membership
+    Object.entries(encodedData.items).forEach(([id, row]) => {
+        Array.from(uniqueColNames).forEach((col) => {
+            let splitCol = col.split('_');
+            row[col] = `${row[splitCol[0]]}`.includes(splitCol[1])
+        })
+    })
+
+    // create the new annotations to pass into process, these are needed to ensure that the columns are added to columnTypes
+    const newAnnotations = Array.from(uniqueColNames).map((col) => {return {[col]: "boolean"}})
+        .reduce((obj, item) => Object.assign(obj, item), {})
+    const annotations = {...encodedData.columnTypes, ...newAnnotations}
+    
+    return (process(Object.values(encodedData.items) as any, { columns: annotations } as any));
+}

--- a/packages/app/src/utils/oneHotEncoding.ts
+++ b/packages/app/src/utils/oneHotEncoding.ts
@@ -12,9 +12,11 @@ export const oneHotEncode = (encodeList: string[], data: CoreUpsetData, empty?: 
     // get the unique names of every new column to be added. 
     //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
     encodeList.forEach((s) => Object.entries(data.items).forEach(([id, row]) => {
-        let names = `${row[s]}`.split(',');
-        names = names.filter((n) => n !== "")
-        newColNames.push(...names.map((val) => `${s}_${val}`))
+        const names = `${row[s]}`
+          .split(',');
+          .filter((n) => n !== "")
+          .map((val) => `${s}_${val}`);
+        newColNames.push(...names)
     }))
     const uniqueColNames: Set<string> = new Set(newColNames);
 

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -123,15 +123,17 @@ export function getFiveNumberSummary(
   const attributes: Attributes = {};
 
   attributeColumns.forEach((attribute) => {
-    const values = memberItems.map((d) => items[d][attribute] as number);
+    const values = memberItems
+      .map((d) => items[d][attribute] as number)
+      .filter((val) => !Number.isNaN(val));
 
     attributes[attribute] = {
-      min: min(values) || 0,
-      max: max(values) || 0,
-      median: median(values) || 0,
-      mean: mean(values) || 0,
-      first: quantile(values, 0.25) || 0,
-      third: quantile(values, 0.75) || 0,
+      min: min(values),
+      max: max(values),
+      median: median(values),
+      mean: mean(values),
+      first: quantile(values, 0.25),
+      third: quantile(values, 0.75),
     };
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,12 +30,12 @@ export type Item = {
 export type Items = { [k: string]: Item };
 
 export type FiveNumberSummary = {
-  min: number;
-  max: number;
-  median: number;
-  mean: number;
-  first: number;
-  third: number;
+  min?: number;
+  max?: number;
+  median?: number;
+  mean?: number;
+  first?: number;
+  third?: number;
 };
 
 export type Attributes = {

--- a/packages/upset/src/atoms/attributeAtom.ts
+++ b/packages/upset/src/atoms/attributeAtom.ts
@@ -13,8 +13,12 @@ export const attributeValuesSelector = selectorFamily<number[], string>({
     (attribute: string) => ({ get }) => {
       const items = get(itemsAtom);
       const values = Object.values(items).map(
-        (val) => val[attribute] as number,
+        (val) => {
+          const retVal = val[attribute] as number;
+          return Number.isNaN(retVal) ? 0 : retVal;
+        },
       );
+
       return values;
     },
 });
@@ -27,6 +31,13 @@ export const attributeMinMaxSelector = selectorFamily<
   get:
     (attribute: string) => ({ get }) => {
       const values = get(attributeValuesSelector(attribute));
+      if (values.includes(NaN)) {
+        return {
+          min: 0,
+          max: 0,
+        };
+      }
+
       return {
         min: Math.min(...values),
         max: Math.max(...values),

--- a/packages/upset/src/atoms/attributeAtom.ts
+++ b/packages/upset/src/atoms/attributeAtom.ts
@@ -12,12 +12,9 @@ export const attributeValuesSelector = selectorFamily<number[], string>({
   get:
     (attribute: string) => ({ get }) => {
       const items = get(itemsAtom);
-      const values = Object.values(items).map(
-        (val) => {
-          const retVal = val[attribute] as number;
-          return Number.isNaN(retVal) ? 0 : retVal;
-        },
-      );
+      const values = Object.values(items)
+        .map((item) => item[attribute] as number)
+        .filter((val) => !Number.isNaN(val));
 
       return values;
     },
@@ -31,12 +28,6 @@ export const attributeMinMaxSelector = selectorFamily<
   get:
     (attribute: string) => ({ get }) => {
       const values = get(attributeValuesSelector(attribute));
-      if (values.includes(NaN)) {
-        return {
-          min: 0,
-          max: 0,
-        };
-      }
 
       return {
         min: Math.min(...values),

--- a/packages/upset/src/components/AttributeBar.tsx
+++ b/packages/upset/src/components/AttributeBar.tsx
@@ -29,10 +29,10 @@ const Tick: FC<{ x1: number; x2: number; y1?: number; y2?: number }> = ({
   />
 );
 
+// this is recomputing every hover event?
 export const AttributeBar: FC<Props> = ({ attribute, summary }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const { min, max } = useRecoilValue(attributeMinMaxSelector(attribute));
-
   const scale = useScale([min, max], [0, dimensions.attribute.width]);
 
   return (

--- a/packages/upset/src/components/AttributeBar.tsx
+++ b/packages/upset/src/components/AttributeBar.tsx
@@ -35,6 +35,10 @@ export const AttributeBar: FC<Props> = ({ attribute, summary }) => {
   const { min, max } = useRecoilValue(attributeMinMaxSelector(attribute));
   const scale = useScale([min, max], [0, dimensions.attribute.width]);
 
+  if (summary.max === undefined || summary.min === undefined || summary.first === undefined || summary.third === undefined || summary.median === undefined) {
+    return null;
+  }
+
   return (
     <g transform={translate(0, dimensions.attribute.plotHeight / 2)}>
       <Tick // Min Tick

--- a/packages/upset/src/components/Header/AttributeHeader.tsx
+++ b/packages/upset/src/components/Header/AttributeHeader.tsx
@@ -2,10 +2,10 @@ import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
-import { itemsAtom } from '../../atoms/itemsAtoms';
 import translate from '../../utils/transform';
 import { AttributeButton } from './AttributeButton';
 import { AttributeScale } from './AttributeScale';
+import { attributeMinMaxSelector } from '../../atoms/attributeAtom';
 
 type Props = {
   attribute: string;
@@ -13,11 +13,7 @@ type Props = {
 
 export const AttributeHeader: FC<Props> = ({ attribute }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
-  const items = useRecoilValue(itemsAtom);
-  const attributes = Object.values(items).map(
-    (item) => item[attribute],
-  ) as number[];
-  const [min, max] = [Math.min(...attributes), Math.max(...attributes)];
+  const { min, max } = useRecoilValue(attributeMinMaxSelector(attribute));
 
   return (
     <>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #237

### Give a longer description of what this PR addresses and why it's needed
Updates the attribute loading to account for any `NaN` values

### Provide pictures/videos of the behavior before and after these changes (optional)
Proper behavior:
![image](https://github.com/visdesignlab/upset2/assets/35744963/489a1ea2-18f4-447b-b1f5-10d0cce1d930)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...