### PR TITLE
Patch: query param cache restoration

### DIFF
--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -13,7 +13,6 @@ import App from './App';
 import DefaultTheme from './components/theme';
 import { api, client_id, oAuth } from './atoms/authAtoms';
 import { readSharedLoginCookie, writeSharedLoginCookie, invalidateSharedLoginCookie } from 'multinet';
-import { restoreQueryParam } from './atoms/queryParamAtom';
 
 // import reportWebVitals from './reportWebVitals';
 
@@ -26,8 +25,6 @@ if (sharedLoginCookie !== null) {
 oAuth.maybeRestoreLogin().then(() => {
 
   Object.assign(api.axios.defaults.headers.common, oAuth.authHeaders);
-
-  restoreQueryParam();
   
   // If logged out, remove the local storage item
   if (!Object.keys(oAuth.authHeaders).includes('Authorization')) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #246

### Give a longer description of what this PR addresses and why it's needed
This fixes the issue of cached query parameters restoring on session load, rather than only when loading the datatable

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...