### PR TITLE
Section headings

### DIFF
--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -140,7 +140,7 @@ const Header = ({ data }: { data: any }) => {
       }}>
         <Box sx={{display: 'flex', flexGrow: '1', justifyContent: 'start', alignItems: 'center', margin: 0, padding: 0}}>
           <img className="logo" id="multinet-logo" src="https://raw.githubusercontent.com/multinet-app/multinet-components/main/src/assets/multinet_logo.svg" alt="Multinet Logo"/>
-          <Typography variant="h6" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal' }}>
+          <Typography variant="h1" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal', fontSize: '1.5em' }}>
             Upset - Visualizing Intersecting Sets
           </Typography>
           <ButtonGroup>

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -140,7 +140,7 @@ const Header = ({ data }: { data: any }) => {
       }}>
         <Box sx={{display: 'flex', flexGrow: '1', justifyContent: 'start', alignItems: 'center', margin: 0, padding: 0}}>
           <img className="logo" id="multinet-logo" src="https://raw.githubusercontent.com/multinet-app/multinet-components/main/src/assets/multinet_logo.svg" alt="Multinet Logo"/>
-          <Typography variant="h1" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal', fontSize: '1.5em' }}>
+          <Typography variant="h1" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal', fontSize: '1.3em' }}>
             Upset - Visualizing Intersecting Sets
           </Typography>
           <ButtonGroup>

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -89,7 +89,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
           `}
         >
           <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
-            Alternative Text
+            Alt Text
           </Typography>
           <IconButton onClick={close}>
             <CloseIcon />

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -88,8 +88,8 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
             width: 95%;
           `}
         >
-          <Typography variant="button" fontSize="1em">
-            Alt Text
+          <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
+            Alternative Text
           </Typography>
           <IconButton onClick={close}>
             <CloseIcon />

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -88,7 +88,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
             width: 95%;
           `}
         >
-          <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
+          <Typography variant="h2" fontSize="1.2em" fontWeight="inherit">
             Alt Text
           </Typography>
           <IconButton onClick={close}>

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -166,7 +166,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
         </IconButton>
       </div>
       <div style={{ marginBottom: '1em' }}>
-        <Typography variant="h2" fontSize="1.5em" fontWeight="inherit" gutterBottom>
+        <Typography variant="h2" fontSize="1.2em" fontWeight="inherit" gutterBottom>
           Element View
         </Typography>
         <Divider />

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -165,17 +165,23 @@ export const ElementSidebar = ({ open, close }: Props) => {
           <CloseIcon />
         </IconButton>
       </div>
-      <Typography variant="button" fontSize="1em">
+      <div style={{ marginBottom: '1em' }}>
+        <Typography variant="h2" fontSize="1.5em" fontWeight="inherit" gutterBottom>
+          Element View
+        </Typography>
+        <Divider />
+      </div>
+      <Typography variant="h3" fontSize="1.2em">
         Element Queries
       </Typography>
       <Divider />
       <ElementQueries />
-      <Typography variant="button" fontSize="1em">
+      <Typography variant="h3" fontSize="1.2em">
         Element Visualization
       </Typography>
       <Divider />
       <ElementVisualization />
-      <Typography variant="button" fontSize="1em">
+      <Typography variant="h3" fontSize="1.2em">
         Query Result
         <Tooltip
           title={

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -48,7 +48,7 @@ export const ProvenanceVis = ({ open, close }: Props) => {
             width: 95%;
           `}
         >
-          <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
+          <Typography variant="h2" fontSize="1.2em" fontWeight="inherit">
             History
           </Typography>
           <IconButton onClick={close}>

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -48,7 +48,7 @@ export const ProvenanceVis = ({ open, close }: Props) => {
             width: 95%;
           `}
         >
-          <Typography variant="button" fontSize="1em">
+          <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
             History
           </Typography>
           <IconButton onClick={close}>

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -161,7 +161,7 @@ export const Root: FC<Props> = ({
           border: 0;
         `}
       >
-        The UpSet 2 interactive plot is currently not screen reader accessible. We are actively working on this and apologize for any inconvienence.
+        The UpSet 2 interactive plot is currently not screen reader accessible. We are actively working on this and apologize for any inconvenience.
       </h2>
       <div
         css={css`

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -148,12 +148,29 @@ export const Root: FC<Props> = ({
       >
         <Sidebar />
       </div>
+      <h2
+        id="desc"
+        css={css`
+          position: absolute; 
+          width: 1px; 
+          height: 1px; 
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0,0,0,0);
+          border: 0;
+        `}
+      >
+        The UpSet 2 interactive plot is currently not screen reader accessible. We are actively working on this and apologize for any inconvienence.
+      </h2>
       <div
         css={css`
           flex: 1 1 auto;
           overflow: auto;
           ${baseStyle};
         `}
+        aria-hidden
+        aria-describedby="desc"
       >
         <SvgBase>
           <Header />

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -84,9 +84,12 @@ export const Sidebar = () => {
         width: ${dimensions.sidebar.width}px
       `}
     >
+      <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
+        Settings
+      </Typography>
       <Accordion disableGutters defaultExpanded>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography css={sidebarHeaderCSS}>Sorting</Typography>
+          <Typography css={sidebarHeaderCSS} variant="h3">Sorting</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl>
@@ -117,7 +120,7 @@ export const Sidebar = () => {
       </Accordion>
       <Accordion disableGutters>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography css={sidebarHeaderCSS}>Aggregation</Typography>
+          <Typography css={sidebarHeaderCSS} variant="h3">Aggregation</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl sx={{ width: '100%' }}>
@@ -168,7 +171,7 @@ export const Sidebar = () => {
         disabled={firstAggregateBy === 'None'}
       >
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography css={sidebarHeaderCSS}>Second Aggregation</Typography>
+          <Typography css={sidebarHeaderCSS} variant="h3">Second Aggregation</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormControl sx={{ width: '100%' }}>
@@ -213,7 +216,7 @@ export const Sidebar = () => {
       </Accordion>
       <Accordion disableGutters>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography css={sidebarHeaderCSS}>Filter Intersections</Typography>
+          <Typography css={sidebarHeaderCSS} variant="h3">Filter Intersections</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormGroup sx={{ mb: 2.5, width: '100%' }}>

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -84,7 +84,7 @@ export const Sidebar = () => {
         width: ${dimensions.sidebar.width}px
       `}
     >
-      <Typography variant="h2" fontSize="1.5em" fontWeight="inherit">
+      <Typography variant="h2" fontSize="1.2em" fontWeight="inherit">
         Settings
       </Typography>
       <Accordion disableGutters defaultExpanded>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #266
Closes #263 

### Give a longer description of what this PR addresses and why it's needed
This PR adds headings to semantic sections (ex. Settings, Alt Text, etc). These are more easily navigable by a screen reader and give context for a user using a screenreader.

Additionally, the PR also adds an `aria-hidden` attribute to the UpSet plot SVG element since it is not screenreader accessible. The element has an `aria-describedby` attribute which points to a (hidden) `h2` element with a quick description of the element and a note that we are working on the accessibility.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/visdesignlab/upset2/assets/35744963/72bd86ca-8f98-475d-a8ae-47a34c992f63)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...