### PR TITLE
Aria tags and general accessibility update

### DIFF
--- a/packages/app/src/atoms/altTextSidebarAtom.ts
+++ b/packages/app/src/atoms/altTextSidebarAtom.ts
@@ -2,5 +2,5 @@ import { atom } from 'recoil';
 
 export const altTextSidebarAtom = atom<boolean>({
   key: 'alt-text-sidebar-state',
-  default: true,
+  default: false,
 });

--- a/packages/app/src/atoms/elementSidebarAtom.ts
+++ b/packages/app/src/atoms/elementSidebarAtom.ts
@@ -2,5 +2,5 @@ import { atom } from 'recoil';
 
 export const elementSidebarAtom = atom<boolean>({
   key: 'element-sidebar-state',
-  default: true,
+  default: false,
 });

--- a/packages/app/src/components/About.tsx
+++ b/packages/app/src/components/About.tsx
@@ -9,27 +9,27 @@ export const About = ({open, close}: Props) => {
     return (
         <Dialog open={open} onClose={close} sx={{padding: "20px"}}>
             <Box sx={{ padding: "20px" }}>
-                <Typography variant="h5" component="h5">About Visualiation Design Lab</Typography>
+                <Typography variant="h5" component="h5">About Visualization Design Lab</Typography>
                 <Box>
                     <p>
-                        For information about VDL, please visit our <a href="https://vdl.sci.utah.edu/" target="_blank" rel="noreferrer">website</a>.
+                        For information about VDL, please visit our <a href="https://vdl.sci.utah.edu/" target="_blank" rel="noreferrer" aria-label="Visualization Design Lab website">website</a>.
                     </p>
                     <p>
-                        To contact us, please email <a href="mailto:vdl-faculty@sci.utah.edu">vdl-faculty@sci.utah.edu</a>.
+                        To contact us, please email <a href="mailto:vdl-faculty@sci.utah.edu" aria-label="Send an email to VDL faculty">vdl-faculty@sci.utah.edu</a>.
                     </p>
                 </Box>
                 <Typography variant="h5" component="h5">About UpSet 2</Typography>
                 <Box>
                     <p>
-                        UpSet 2 is an open source tool for visualizing set intersections based on <a href="https://vdl.sci.utah.edu/publications/2014_infovis_upset/" target="_blank" rel="noreferrer">UpSet: Visualization of Intersecting Sets (2014)</a>.
+                        UpSet 2 is an open source tool for visualizing set intersections based on <a href="https://vdl.sci.utah.edu/publications/2014_infovis_upset/" target="_blank" rel="noreferrer" aria-label="Read the 2014 UpSet paper">UpSet: Visualization of Intersecting Sets (2014)</a>.
                         <br />
-                        For more information on UpSet 2, see <a href="https://vdl.sci.utah.edu/publications/2019_infovis_upset/" target="_blank" rel="noreferrer">UpSet 2: From Prototype to Tool (2019)</a>.
+                        For more information on UpSet 2, see <a href="https://vdl.sci.utah.edu/publications/2019_infovis_upset/" target="_blank" rel="noreferrer" aria-label="Read the 2019 UpSet 2 prototype paper">UpSet 2: From Prototype to Tool (2019)</a>.
                     </p>
                     <p>
-                        To make contributions and/or report a bug, please visit our <a href="https://github.com/visdesignlab/upset2" target="_blank" rel="noreferrer">GitHub repository</a>.
+                        To make contributions and/or report a bug, please visit our <a href="https://github.com/visdesignlab/upset2" target="_blank" rel="noreferrer" aria-label="open the UpSet 2 github repository">GitHub repository</a>.
                     </p> 
                     <p>
-                        Development of UpSet is supported by the <a href="https://vdl.sci.utah.edu/projects/2022-czi-upset/" target="_blank" rel="noreferrer">Chan Zuckerberg Initiative</a>.
+                        Development of UpSet is supported by the <a href="https://vdl.sci.utah.edu/projects/2022-czi-upset/" target="_blank" rel="noreferrer" aria-label="Read more about the Chan Zuckerberg Initiative">Chan Zuckerberg Initiative</a>.
                     </p>
                 </Box>
             </Box>

--- a/packages/app/src/components/About.tsx
+++ b/packages/app/src/components/About.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Box, Typography, Button } from "@mui/material";
+import { Dialog, Box, Typography, Button, Link } from "@mui/material";
 
 type Props = {
     open: boolean;
@@ -9,27 +9,27 @@ export const About = ({open, close}: Props) => {
     return (
         <Dialog open={open} onClose={close} sx={{padding: "20px"}}>
             <Box sx={{ padding: "20px" }}>
-                <Typography variant="h5" component="h5">About Visualization Design Lab</Typography>
+                <Typography variant="h5" component="h5">About Visualization Design Lab (VDL)</Typography>
                 <Box>
                     <p>
-                        For information about VDL, please visit our <a href="https://vdl.sci.utah.edu/" target="_blank" rel="noreferrer" aria-label="Visualization Design Lab website">website</a>.
+                        For information about VDL, please visit our <Link href="https://vdl.sci.utah.edu/" target="_blank" rel="noreferrer" aria-label="VDL website">website</Link>.
                     </p>
                     <p>
-                        To contact us, please email <a href="mailto:vdl-faculty@sci.utah.edu" aria-label="Send an email to VDL faculty">vdl-faculty@sci.utah.edu</a>.
+                        To contact us, please email <Link href="mailto:vdl-faculty@sci.utah.edu" aria-label="VDL faculty email">vdl-faculty@sci.utah.edu</Link>.
                     </p>
                 </Box>
                 <Typography variant="h5" component="h5">About UpSet 2</Typography>
                 <Box>
                     <p>
-                        UpSet 2 is an open source tool for visualizing set intersections based on <a href="https://vdl.sci.utah.edu/publications/2014_infovis_upset/" target="_blank" rel="noreferrer" aria-label="Read the 2014 UpSet paper">UpSet: Visualization of Intersecting Sets (2014)</a>.
+                        UpSet 2 is an open source tool for visualizing set intersections based on <Link href="https://vdl.sci.utah.edu/publications/2014_infovis_upset/" target="_blank" rel="noreferrer">UpSet: Visualization of Intersecting Sets (2014)</Link>.
                         <br />
-                        For more information on UpSet 2, see <a href="https://vdl.sci.utah.edu/publications/2019_infovis_upset/" target="_blank" rel="noreferrer" aria-label="Read the 2019 UpSet 2 prototype paper">UpSet 2: From Prototype to Tool (2019)</a>.
+                        For more information on UpSet 2, see <Link href="https://vdl.sci.utah.edu/publications/2019_infovis_upset/" target="_blank" rel="noreferrer">UpSet 2: From Prototype to Tool (2019)</Link>.
                     </p>
                     <p>
-                        To make contributions and/or report a bug, please visit our <a href="https://github.com/visdesignlab/upset2" target="_blank" rel="noreferrer" aria-label="open the UpSet 2 github repository">GitHub repository</a>.
+                        To make contributions and/or report a bug, please visit our <Link href="https://github.com/visdesignlab/upset2" target="_blank" rel="noreferrer">UpSet2 GitHub repository</Link>.
                     </p> 
                     <p>
-                        Development of UpSet is supported by the <a href="https://vdl.sci.utah.edu/projects/2022-czi-upset/" target="_blank" rel="noreferrer" aria-label="Read more about the Chan Zuckerberg Initiative">Chan Zuckerberg Initiative</a>.
+                        Development of UpSet is supported by the <Link href="https://vdl.sci.utah.edu/projects/2022-czi-upset/" target="_blank" rel="noreferrer">Chan Zuckerberg Initiative</Link>.
                     </p>
                 </Box>
             </Box>

--- a/packages/app/src/components/AccessiblityStatement.tsx
+++ b/packages/app/src/components/AccessiblityStatement.tsx
@@ -14,7 +14,7 @@ export const AccessibilityStatement = ({open, close}: Props) => {
                 <Typography variant="h4" component="h4">UpSet 2 Accessibility Statement</Typography>
                 <p>
                     The Visualization Design Lab at the University of Utah is committed to ensuring accessibility for all individuals, including those with disabilities. 
-                    We strive to make our software user-friendly, accessible, and compliant with the <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noreferrer">Web Content Accessibility Guidelines (WCAG)</a> 2.1 Level AA.
+                    We strive to make our software user-friendly, accessible, and compliant with the <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noreferrer" aria-label='Read more about web content accessibility guidelines'>Web Content Accessibility Guidelines (WCAG)</a> 2.1 Level AA.
                 </p>
                 <p>
                     Despite our ongoing efforts to provide an inclusive experience, we would like to acknowledge that certain aspects of our software may currently pose accessibility challenges. 
@@ -46,7 +46,7 @@ export const AccessibilityStatement = ({open, close}: Props) => {
                     Please be assured that we have plans in place to address these accessibility limitations and make UpSet2 fully inclusive.
                 </p>
                 <p>
-                    To report any accessibility issues you may encounter or to provide suggestions for improvement, please contact us at <a type="email" href="mailto:vdl-faculty@sci.utah.edu">vdl-faculty@sci.utah.edu</a>. 
+                    To report any accessibility issues you may encounter or to provide suggestions for improvement, please contact us at <a type="email" href="mailto:vdl-faculty@sci.utah.edu" aria-label='Send an email to VDL faculty'>vdl-faculty@sci.utah.edu</a>. 
                     We value your feedback and are committed to continuously enhancing the accessibility and usability of our software.
                 </p>
                 <p>

--- a/packages/app/src/components/AccessiblityStatement.tsx
+++ b/packages/app/src/components/AccessiblityStatement.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Dialog, Typography } from "@mui/material";
+import { Box, Button, Dialog, Link, Typography } from "@mui/material";
 
 type Props = {
     open: boolean;
@@ -14,7 +14,7 @@ export const AccessibilityStatement = ({open, close}: Props) => {
                 <Typography variant="h4" component="h4">UpSet 2 Accessibility Statement</Typography>
                 <p>
                     The Visualization Design Lab at the University of Utah is committed to ensuring accessibility for all individuals, including those with disabilities. 
-                    We strive to make our software user-friendly, accessible, and compliant with the <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noreferrer" aria-label='Read more about web content accessibility guidelines'>Web Content Accessibility Guidelines (WCAG)</a> 2.1 Level AA.
+                    We strive to make our software user-friendly, accessible, and compliant with the <Link href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noreferrer" aria-label='Read more about web content accessibility guidelines'>Web Content Accessibility Guidelines (WCAG)</Link> 2.1 Level AA.
                 </p>
                 <p>
                     Despite our ongoing efforts to provide an inclusive experience, we would like to acknowledge that certain aspects of our software may currently pose accessibility challenges. 
@@ -46,7 +46,7 @@ export const AccessibilityStatement = ({open, close}: Props) => {
                     Please be assured that we have plans in place to address these accessibility limitations and make UpSet2 fully inclusive.
                 </p>
                 <p>
-                    To report any accessibility issues you may encounter or to provide suggestions for improvement, please contact us at <a type="email" href="mailto:vdl-faculty@sci.utah.edu" aria-label='Send an email to VDL faculty'>vdl-faculty@sci.utah.edu</a>. 
+                    To report any accessibility issues you may encounter or to provide suggestions for improvement, please contact us at <Link type="email" href="mailto:vdl-faculty@sci.utah.edu" aria-label='VDL faculty email'>vdl-faculty@sci.utah.edu</Link>. 
                     We value your feedback and are committed to continuously enhancing the accessibility and usability of our software.
                 </p>
                 <p>

--- a/packages/app/src/components/DataTable.tsx
+++ b/packages/app/src/components/DataTable.tsx
@@ -120,7 +120,7 @@ export const DataTable = () => {
     const getSetRows = (sets: string[], data: CoreUpsetData) => {
         const retVal: {setName: string, size: number}[] = [];
         retVal.push(...sets.map((s: string) => {
-            return {id: s, setName: s, size: data.sets[s].size};
+            return {id: s, setName: s.replace('Set_', ''), size: data.sets[s].size};
         }));
 
         return retVal;

--- a/packages/app/src/components/ErrorModal.tsx
+++ b/packages/app/src/components/ErrorModal.tsx
@@ -38,8 +38,8 @@ export const ErrorModal = () => {
     }
     
     return (
-        <Dialog open={true} >
-            <DialogTitle>Error</DialogTitle>
+        <Dialog open={true}>
+            <DialogTitle>Import Error</DialogTitle>
             <DialogContent>
                 <DialogContentText>The provided data is in an incompatible form for visualization with Upset. To visualize this dataset, please upload set-based data or, if compatible, select columns to one-hot encode.</DialogContentText>
                 { needOneHot && 
@@ -61,7 +61,7 @@ export const ErrorModal = () => {
                             input={<OutlinedInput label="Columns to encode" />}
                             renderValue={(selected: any) => selected.join(', ')}
                             MenuProps={MenuProps}
-                            >
+                        >
                             {Object.entries(data.columnTypes).map(([name, type]) => (
                                 <MenuItem key={name} value={name}>
                                 <Checkbox checked={encodeList.includes(name)} />

--- a/packages/app/src/components/Footer/index.tsx
+++ b/packages/app/src/components/Footer/index.tsx
@@ -51,9 +51,9 @@ const Footer = () => {
         <Box sx={{ position: "absolute", bottom: 0, width: "100%" }}>
             <footer>
                 <Box sx={{backgroundColor: "#e0e0e0", width: "100%", display: "flex", justifyContent: "space-around", padding: "5px 0"}}>
-                    <FooterButton onClick={() => setAboutModal(true)} icon={<img src={vdl_logo} alt="About Us" height="32px" width="100%" />} />
-                    <FooterButton href={"https://github.com/visdesignlab/upset2/issues"} label={"Report a Bug"} icon={<BugReport />} />
-                    <FooterButton onClick={() => setAccessibilityStatement(true)} label={"Accessibility"} icon={<AccessibilityNew />} tabIndex={1} />
+                    <FooterButton onClick={() => setAboutModal(true)} aria-label="Open About Us modal" icon={<img src={vdl_logo} alt="About Us" height="32px" width="100%" />} />
+                    <FooterButton href={"https://github.com/visdesignlab/upset2/issues"} aria-label="Open GitHub issues for this project" label={"Report a Bug"} icon={<BugReport />} />
+                    <FooterButton onClick={() => setAccessibilityStatement(true)} label={"Accessibility"} aria-label="Open Accessibility Statement modal" icon={<AccessibilityNew />} tabIndex={1} />
 
                     {/* Accessibility Statement dialog */}
                     <AccessibilityStatement open={accessibilityStatement} close={() => setAccessibilityStatement(false)} />

--- a/packages/app/src/components/Footer/index.tsx
+++ b/packages/app/src/components/Footer/index.tsx
@@ -51,9 +51,9 @@ const Footer = () => {
         <Box sx={{ position: "absolute", bottom: 0, width: "100%" }}>
             <footer>
                 <Box sx={{backgroundColor: "#e0e0e0", width: "100%", display: "flex", justifyContent: "space-around", padding: "5px 0"}}>
-                    <FooterButton onClick={() => setAboutModal(true)} aria-label="Open About Us modal" icon={<img src={vdl_logo} alt="About Us" height="32px" width="100%" />} />
+                    <FooterButton onClick={() => setAboutModal(true)} aria-label="Open About Us modal" aria-haspopup="dialog" icon={<img src={vdl_logo} alt="About Us" height="32px" width="100%" />} />
                     <FooterButton href={"https://github.com/visdesignlab/upset2/issues"} aria-label="Open GitHub issues for this project" label={"Report a Bug"} icon={<BugReport />} />
-                    <FooterButton onClick={() => setAccessibilityStatement(true)} label={"Accessibility"} aria-label="Open Accessibility Statement modal" icon={<AccessibilityNew />} tabIndex={1} />
+                    <FooterButton onClick={() => setAccessibilityStatement(true)} label={"Accessibility"} aria-label="Open Accessibility Statement modal" aria-haspopup="dialog" icon={<AccessibilityNew />} tabIndex={1} />
 
                     {/* Accessibility Statement dialog */}
                     <AccessibilityStatement open={accessibilityStatement} close={() => setAccessibilityStatement(false)} />

--- a/packages/app/src/components/Footer/index.tsx
+++ b/packages/app/src/components/Footer/index.tsx
@@ -1,5 +1,5 @@
 import { AccessibilityNew, BugReport } from "@mui/icons-material";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Button, Link } from "@mui/material";
 import vdl_logo from "../../assets/vdl_logo.svg";
 import { accessibilityStatementAtom } from "../../atoms/accessibilityStatementAtom";
 import { useRecoilState } from "recoil";
@@ -18,46 +18,58 @@ const Footer = () => {
     const [ accessibilityStatement, setAccessibilityStatement ] = useRecoilState(accessibilityStatementAtom);
     const [ aboutModal, setAboutModal ] = useRecoilState(aboutAtom);
 
-    type FooterButtonProps = {
-        icon: JSX.Element,
-        label?: string,
-        href?: string,
-        onClick?: () => void,
-        tabIndex?: number,
-    }
-    
-    const FooterButton = ({ href, onClick, label, icon, tabIndex }: FooterButtonProps) => {
-        return (
-            <a href={href} target="_blank" rel="noreferrer" style={{textDecoration: "none", color: "inherit"}}>
-                <Button
-                    sx={categoryCSS}
-                    variant="contained"
-                    color="inherit"
-                    size="medium"
-                    disableElevation
-                    startIcon={icon}
-                    tabIndex={tabIndex ? tabIndex : 0}
-                    onClick={onClick}
-                >
-                    { label &&
-                        <Typography variant="button" align="center">{label}</Typography>
-                    }
-                </Button>
-            </a>
-        )
-    }
-
     return (
         <Box sx={{ position: "absolute", bottom: 0, width: "100%" }}>
             <footer>
                 <Box sx={{backgroundColor: "#e0e0e0", width: "100%", display: "flex", justifyContent: "space-around", padding: "5px 0"}}>
-                    <FooterButton onClick={() => setAboutModal(true)} aria-label="Open About Us modal" aria-haspopup="dialog" icon={<img src={vdl_logo} alt="About Us" height="32px" width="100%" />} />
-                    <FooterButton href={"https://github.com/visdesignlab/upset2/issues"} aria-label="Open GitHub issues for this project" label={"Report a Bug"} icon={<BugReport />} />
-                    <FooterButton onClick={() => setAccessibilityStatement(true)} label={"Accessibility"} aria-label="Open Accessibility Statement modal" aria-haspopup="dialog" icon={<AccessibilityNew />} tabIndex={1} />
+                    <Button
+                        sx={categoryCSS}
+                        variant="contained"
+                        color="inherit"
+                        size="medium"
+                        disableElevation
+                        aria-label="Open About Us modal"
+                        aria-haspopup="dialog"
+                        onClick={() => setAboutModal(true)}
+                    >
+                        <img src={vdl_logo} alt="About Us" height="32px" width="100%" />
+                    </Button>
+                    <Link
+                        href="https://github.com/visdesignlab/upset2/issues"
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label="Open GitHub issues for this project"
+                    >
+                        <Button
+                            sx={categoryCSS}
+                            variant="contained"
+                            color="inherit"
+                            size="medium"
+                            disableElevation
+                            startIcon={<BugReport />}
+                        >
+                            Report a Bug
+                        </Button>
+                    </Link>
+
+                    <Button
+                        sx={categoryCSS}
+                        variant="contained"
+                        color="inherit"
+                        size="medium"
+                        disableElevation
+                        startIcon={<AccessibilityNew />}
+                        aria-label="Open Accessibility Statement modal"
+                        aria-haspopup="dialog"
+                        tabIndex={1}
+                        onClick={() => setAccessibilityStatement(true)}
+                    >
+                        Accessibility Statement
+                    </Button>
 
                     {/* Accessibility Statement dialog */}
                     <AccessibilityStatement open={accessibilityStatement} close={() => setAccessibilityStatement(false)} />
-                    {/* "About" dialog */}
+                    {/* About dialog */}
                     <About open={aboutModal} close={() => setAboutModal(false)} />
                 </Box>
             </footer>

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -144,10 +144,10 @@ const Header = ({ data }: { data: any }) => {
             Upset - Visualizing Intersecting Sets
           </Typography>
           <ButtonGroup>
-            <IconButton color="inherit" onClick={() => provenance.undo()} disabled={trrackPosition.isAtRoot}>
+            <IconButton color="inherit" onClick={() => provenance.undo()} disabled={trrackPosition.isAtRoot} aria-label="Undo">
               <UndoIcon />
             </IconButton>
-            <IconButton color="inherit" onClick={() => provenance.redo()} disabled={trrackPosition.isAtLatest}>
+            <IconButton color="inherit" onClick={() => provenance.redo()} disabled={trrackPosition.isAtLatest} aria-label="Redo">
               <RedoIcon />
             </IconButton>
           </ButtonGroup>
@@ -173,20 +173,24 @@ const Header = ({ data }: { data: any }) => {
               <Button
                 color="inherit"
                 onClick={(e) => { handleAttributeClick(e) }}
+                aria-label="Open attributes selection menu"
               >
                 Attributes
               </Button>
-              <Button onClick={() => {
-                closeAnySidebar();
+              <Button 
+                onClick={() => {
+                  closeAnySidebar();
 
-                if (isElementSidebarOpen) {
-                  setIsElementSidebarOpen(false);
-                } else {
-                  setIsElementSidebarOpen(true);
-                }
+                  if (isElementSidebarOpen) {
+                    setIsElementSidebarOpen(false);
+                  } else {
+                    setIsElementSidebarOpen(true);
+                  }
 
-                handleMenuClose();
-              }}>
+                  handleMenuClose();
+                }}
+                aria-label='Open element view sidebar'
+              >
                 Element View
               </Button>
             </>
@@ -206,21 +210,30 @@ const Header = ({ data }: { data: any }) => {
                 window.location.href = getMultinetDataUrl(workspace);
               }
             }}
+            aria-label='Load data from Multinet'
           >
             Load Data
           </Button>
-          <Button sx={{ minWidth: "24px" }} onKeyDown={(e) => handleMenuKeypress(e)} ><MoreVertIcon onClick={(e) => handleMenuClick(e.currentTarget)}></MoreVertIcon></Button>
+          <Button
+           sx={{ minWidth: "24px" }}
+           onKeyDown={(e) => handleMenuKeypress(e)}
+           aria-label='Open additional options menu'
+          >
+            <MoreVertIcon
+              onClick={(e) => handleMenuClick(e.currentTarget)}
+            ></MoreVertIcon>
+          </Button>
             <Menu open={isMenuOpen} onClose={handleMenuClose} anchorEl={anchorEl}>
-              <MenuItem onClick={() => setShowImportModal(true) } color="inherit">
+              <MenuItem onClick={() => setShowImportModal(true) } color="inherit" aria-label="Import UpSet JSON state file">
                 Import State
               </MenuItem>
-              <MenuItem onClick={() => exportState(provenance)} color="inherit">
+              <MenuItem onClick={() => exportState(provenance)} color="inherit" aria-label="Export UpSet JSON state file">
                 Export State
               </MenuItem>
-              <MenuItem onClick={() => exportState(provenance, data, getRows(data, provenance.getState()))}>
+              <MenuItem onClick={() => exportState(provenance, data, getRows(data, provenance.getState()))} aria-label="Export UpSet JSON state file with table data included">
                 Export State + Data
               </MenuItem>
-              <MenuItem onClick={() => downloadSVG()}>
+              <MenuItem onClick={() => downloadSVG()} aria-label="Download the UpSet plot as an SVG">
                 Download SVG
               </MenuItem>
               <MenuItem onClick={() => {
@@ -228,7 +241,9 @@ const Header = ({ data }: { data: any }) => {
 
                   setIsProvVisOpen(true); 
                   handleMenuClose();
-                }}>
+                }}
+                aria-label='Open history tree sidebar'  
+              >
                   Show History
               </MenuItem>
             </Menu>
@@ -238,6 +253,7 @@ const Header = ({ data }: { data: any }) => {
             onClick={(e) => {
               handleLoginOpen(e);
             }}
+            aria-label="Login/Logout"
           >
             <Avatar sx={{ width: "32px", height: "32px" }} alt="User login status icon" variant="circular">
               {userInfo !== null ?
@@ -252,14 +268,18 @@ const Header = ({ data }: { data: any }) => {
             anchorEl={anchorEl}
           >
           {userInfo === null ?
-            <MenuItem onClick={() => {
-              restoreQueryParam();
-              oAuth.redirectToLogin();
-            }}>Login</MenuItem>
-            : <MenuItem onClick={() => {
-              oAuth.logout();
-              window.location.reload();
-            }}>Log out</MenuItem>
+            <MenuItem
+              onClick={() => {
+                restoreQueryParam();
+                oAuth.redirectToLogin();
+              }}
+            >Login</MenuItem>
+            : <MenuItem
+                onClick={() => {
+                  oAuth.logout();
+                  window.location.reload();
+                }}
+              >Log out</MenuItem>
           }
           </Menu>
         </Box>

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -159,7 +159,9 @@ const Header = ({ data }: { data: any }) => {
                 closeAnySidebar();
 
                 setIsAltTextSidebarOpen(true);
-              }}>
+              }}
+              aria-label="Open alt text sidebar"
+              >
                 Show Alt-Text
               </Button>
               <Link to={`/datatable${getQueryParam()}`} target="_blank" rel="noreferrer" onClick={dispatchState} style={{textDecoration: "none", color: "inherit"}} aria-label='Open raw and computed data as tables in a new tab'>
@@ -174,6 +176,7 @@ const Header = ({ data }: { data: any }) => {
                 color="inherit"
                 onClick={(e) => { handleAttributeClick(e) }}
                 aria-label="Open attributes selection menu"
+                aria-haspopup="menu"
               >
                 Attributes
               </Button>
@@ -218,6 +221,7 @@ const Header = ({ data }: { data: any }) => {
            sx={{ minWidth: "24px" }}
            onKeyDown={(e) => handleMenuKeypress(e)}
            aria-label='Open additional options menu'
+           aria-haspopup="menu"
           >
             <MoreVertIcon
               onClick={(e) => handleMenuClick(e.currentTarget)}
@@ -227,10 +231,10 @@ const Header = ({ data }: { data: any }) => {
               <MenuItem onClick={() => setShowImportModal(true) } color="inherit" aria-label="Import UpSet JSON state file">
                 Import State
               </MenuItem>
-              <MenuItem onClick={() => exportState(provenance)} color="inherit" aria-label="Export UpSet JSON state file">
+              <MenuItem onClick={() => exportState(provenance)} color="inherit" aria-label="Download UpSet JSON state file">
                 Export State
               </MenuItem>
-              <MenuItem onClick={() => exportState(provenance, data, getRows(data, provenance.getState()))} aria-label="Export UpSet JSON state file with table data included">
+              <MenuItem onClick={() => exportState(provenance, data, getRows(data, provenance.getState()))} aria-label="Download UpSet JSON state file with table data included">
                 Export State + Data
               </MenuItem>
               <MenuItem onClick={() => downloadSVG()} aria-label="Download the UpSet plot as an SVG">
@@ -253,7 +257,8 @@ const Header = ({ data }: { data: any }) => {
             onClick={(e) => {
               handleLoginOpen(e);
             }}
-            aria-label="Login/Logout"
+            aria-label="Open login menu"
+            aria-haspopup="menu"
           >
             <Avatar sx={{ width: "32px", height: "32px" }} alt="User login status icon" variant="circular">
               {userInfo !== null ?

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -158,11 +158,15 @@ const Header = ({ data }: { data: any }) => {
               <Button color="inherit" onClick={() => {
                 closeAnySidebar();
 
-                setIsAltTextSidebarOpen(true);
+                if (isAltTextSidebarOpen) {
+                  setIsAltTextSidebarOpen(false);
+                } else {
+                  setIsAltTextSidebarOpen(true);
+                }
               }}
-              aria-label="Open alt text sidebar"
+              aria-label={`${isAltTextSidebarOpen ? 'Close' : 'Open'} alt text sidebar`}
               >
-                Show Alt-Text
+                Alt-Text
               </Button>
               <Link to={`/datatable${getQueryParam()}`} target="_blank" rel="noreferrer" onClick={dispatchState} style={{textDecoration: "none", color: "inherit"}} aria-label='Open raw and computed data as tables in a new tab'>
                 <Button
@@ -184,15 +188,13 @@ const Header = ({ data }: { data: any }) => {
                 onClick={() => {
                   closeAnySidebar();
 
-                  if (isElementSidebarOpen) {
-                    setIsElementSidebarOpen(false);
-                  } else {
+                  if (!isElementSidebarOpen) {
                     setIsElementSidebarOpen(true);
                   }
 
                   handleMenuClose();
                 }}
-                aria-label='Open element view sidebar'
+                aria-label={`${isElementSidebarOpen ? 'Close' : 'Open'} element view sidebar`}
               >
                 Element View
               </Button>

--- a/packages/app/src/components/Home.tsx
+++ b/packages/app/src/components/Home.tsx
@@ -12,7 +12,7 @@ export const Home = () => {
                     <Typography variant="body1" color="text.secondary">
                         You haven't loaded data, you can't access the workspace you are attemping to view, or you are not logged in. 
                         To log in, click the account icon in the top right corner.
-                        To load stored data or upload new data, visit <Link href="https://multinet.app" color="secondary.dark">multinet.app</Link>.
+                        To load stored data or upload new data, visit <Link href="https://multinet.app" aria-label="Navigate to Multinet homepage" color="secondary.dark">multinet.app</Link>.
                     </Typography>
                     <Typography variant="h5" color="text.primary" sx={{marginTop: "1rem"}}>
                         Examples
@@ -21,7 +21,7 @@ export const Home = () => {
                         If this is your first time visiting UpSet, click on the images below to explore some examples.
                     </Typography>
                     <Box sx={{display: 'flex', justifyContent: 'space-around', alignItems: 'center', width: '100%', marginTop: '1em'}}>
-                        <Card sx={{boxShadow: 4, borderRadius: "8px"}}>
+                        <Card sx={{boxShadow: 4, borderRadius: "8px"}} aria-label="Example of a dataset of movies in UpSet">
                             <CardActionArea onClick={() => window.open('https://upset.multinet.app/?workspace=Upset+Examples&table=movies&sessionId=192')}>
                                 <CardMedia component="img" height="250" image="/placard/movies.png" alt="Example UpSet plot: movies" />
                                 <CardContent sx={{paddingLeft: 0}}>
@@ -31,7 +31,7 @@ export const Home = () => {
                                 </CardContent>
                             </CardActionArea>
                         </Card>
-                        <Card sx={{boxShadow: 4, borderRadius: "8px"}}>
+                        <Card sx={{boxShadow: 4, borderRadius: "8px"}} aria-label="Example of a dataset of Simpsons character attributes in UpSet">
                             <CardActionArea onClick={() => window.open('https://upset.multinet.app/?workspace=Upset+Examples&table=simpsons&sessionId=193')}>
                                 <CardMedia component="img" height="250" image="/placard/simpsons.png" alt="Example UpSet plot: simpsons" />
                                 <CardContent sx={{paddingLeft: 0}}>

--- a/packages/app/src/components/ImportModal.tsx
+++ b/packages/app/src/components/ImportModal.tsx
@@ -58,6 +58,7 @@ export const ImportModal = (props:{open: boolean, close: () => void}) => {
               <Button 
                 variant="contained" 
                 size="small"
+                aria-errormessage='import-error'
                 onClick={() => {
                   const input: HTMLInputElement | null = document.getElementById('state-upload-file') as HTMLInputElement;
                   
@@ -75,7 +76,7 @@ export const ImportModal = (props:{open: boolean, close: () => void}) => {
         </DialogContent>
           <Snackbar
             open={isError.isOpen} autoHideDuration={6000} onClose={() => setIsError({...isError, isOpen: false})}>
-            <Alert severity="error">{isError.message}</Alert>
+            <Alert severity="error"><div id="import-error">{isError.message}</div></Alert>
           </Snackbar>
     </Dialog>
   );

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -67,6 +67,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       open={open}
       onClose={close}
       variant="persistent"
+      aria-label="Alt Text Sidebar"
       sx={{
         width: (open) ? initialDrawerWidth : 0,
         flexShrink: 0,

--- a/packages/upset/src/components/ElementView/ElementQueries.tsx
+++ b/packages/upset/src/components/ElementView/ElementQueries.tsx
@@ -32,6 +32,7 @@ export const ElementQueries = () => {
         <Alert
           severity="info"
           variant="outlined"
+          role="generic"
           sx={{
             alignItems: 'center', margin: '0.5em 0', border: 'none', color: '#777777',
           }}

--- a/packages/upset/src/components/ElementView/ElementQueries.tsx
+++ b/packages/upset/src/components/ElementView/ElementQueries.tsx
@@ -55,6 +55,13 @@ export const ElementQueries = () => {
                   : 'default',
             })}
             key={bookmark.id}
+            aria-label={`Bookmarked intersection ${bookmark.label}, size ${bookmark.size}`}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                if (currentIntersection?.id === bookmark.id) setCurrentIntersection(null);
+                else setCurrentIntersection(rows[bookmark.id]);
+              }
+            }}
             label={`${bookmark.label} - ${bookmark.size}`}
             icon={<SquareIcon fontSize={'1em' as any} />}
             deleteIcon={<StarIcon />}
@@ -80,6 +87,16 @@ export const ElementQueries = () => {
             backgroundColor: 'rgba(0,0,0,0.2)',
           })}
           icon={<SquareIcon fontSize={'1em' as any} />}
+          aria-label={`Selected intersection ${currentIntersection.elementName}, size ${currentIntersection.size}`}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              actions.bookmarkIntersection(
+                currentIntersection.id,
+                currentIntersection.elementName,
+                currentIntersection.size,
+              );
+            }
+          }}
           label={`${currentIntersection.elementName} - ${currentIntersection.size}`}
           onDelete={() => {
             actions.bookmarkIntersection(

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -213,6 +213,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
         <Alert
           severity="info"
           variant="outlined"
+          role="generic"
           sx={{
             alignItems: 'center', marginTop: '0.5em', border: 'none', color: '#777777',
           }}

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -141,6 +141,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
             onClick={() => {
               setFullWidth(true);
             }}
+            aria-label="Expand the sidebar in full screen"
           >
             <OpenInFullIcon />
           </IconButton>
@@ -153,6 +154,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
                 setHideElementSidebar(true);
               }
             }}
+            aria-label="Reduce the sidebar to normal size"
           >
             <CloseFullscreen />
           </IconButton>}
@@ -161,6 +163,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
             setHideElementSidebar(true);
             close();
           }}
+          aria-label="Close the sidebar"
         >
           <CloseIcon />
         </IconButton>

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -115,6 +115,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
       onClose={close}
       variant="persistent"
       anchor="right"
+      aria-label="Element View sidebar"
     >
       <Box
         sx={{

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -27,6 +27,7 @@ export const ProvenanceVis = ({ open, close }: Props) => {
       open={open}
       onClose={close}
       variant="persistent"
+      aria-label="History Sidebar"
       sx={{
         width: (open) ? initialDrawerWidth : 0,
         flexShrink: 0,

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -101,7 +101,7 @@ export const Sidebar = () => {
             >
               {sortByList.map((sort) => (sort === 'Deviation' ?
                 (
-                  <Alert severity="info" variant="outlined" key={sort} sx={{ alignItems: 'center', padding: '0.1em 0.4em', marginTop: '0.5em' }}><Typography>Use column headers for custom sorting</Typography></Alert>
+                  <Alert severity="info" variant="outlined" role="generic" key={sort} sx={{ alignItems: 'center', padding: '0.1em 0.4em', marginTop: '0.5em' }}><Typography>Use column headers for custom sorting</Typography></Alert>
                 ) :
                 (
                   <div css={itemDivCSS} key={sort}>

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Alert,
+  Box,
   FormControl,
   FormControlLabel,
   FormGroup,
@@ -104,7 +105,16 @@ export const Sidebar = () => {
                   <Alert severity="info" variant="outlined" role="generic" key={sort} sx={{ alignItems: 'center', padding: '0.1em 0.4em', marginTop: '0.5em' }}><Typography>Use column headers for custom sorting</Typography></Alert>
                 ) :
                 (
-                  <div css={itemDivCSS} key={sort}>
+                  <Box
+                    css={itemDivCSS}
+                    key={sort}
+                    aria-label={helpText.sorting[sort]}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        actions.sortBy(sort);
+                      }
+                    }}
+                  >
                     <FormControlLabel
                       key={sort}
                       value={sort}
@@ -112,7 +122,7 @@ export const Sidebar = () => {
                       control={<Radio size="small" />}
                     />
                     <HelpCircle text={helpText.sorting[sort]} />
-                  </div>
+                  </Box>
                 )))}
             </RadioGroup>
           </FormControl>
@@ -133,7 +143,16 @@ export const Sidebar = () => {
             >
               {aggregateByList.map((agg) => (
                 <Fragment key={agg}>
-                  <div css={itemDivCSS}>
+                  <Box
+                    css={itemDivCSS}
+                    key={agg}
+                    aria-label={agg !== 'None' ? helpText.aggregation[agg] : undefined}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        actions.firstAggregateBy(agg);
+                      }
+                    }}
+                  >
                     <FormControlLabel
                       key={agg}
                       value={agg}
@@ -141,9 +160,10 @@ export const Sidebar = () => {
                       control={<Radio size="small" />}
                     />
                     {agg !== 'None' && <HelpCircle text={helpText.aggregation[agg]} />}
-                  </div>
+                  </Box>
                   {agg === 'Overlaps' && firstAggregateBy === agg && (
                     <TextField
+                      aria-label="Select the overlap degree (minimum 2)"
                       label="Degree"
                       size="small"
                       type="number"
@@ -186,16 +206,26 @@ export const Sidebar = () => {
                 .filter((agg) => agg !== firstAggregateBy)
                 .map((agg) => (
                   <Fragment key={agg}>
-                    <div css={itemDivCSS}>
+                    <Box
+                      css={itemDivCSS}
+                      key={agg}
+                      aria-label={agg !== 'None' ? helpText.aggregation[agg] : 'No aggregation'}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          actions.secondAggregateBy(agg);
+                        }
+                      }}
+                    >
                       <FormControlLabel
                         value={agg}
                         label={agg}
                         control={<Radio size="small" />}
                       />
                       {agg !== 'None' && <HelpCircle text={helpText.aggregation[agg]} />}
-                    </div>
+                    </Box>
                     {agg === 'Overlaps' && secondAggregateBy === agg && (
                       <TextField
+                        aria-label="Select the overlap degree (minimum 2)"
                         label="Degree"
                         size="small"
                         type="number"
@@ -220,7 +250,15 @@ export const Sidebar = () => {
         </AccordionSummary>
         <AccordionDetails>
           <FormGroup sx={{ mb: 2.5, width: '100%' }}>
-            <div css={itemDivCSS}>
+            <Box
+              css={itemDivCSS}
+              aria-label={helpText.filter.HideEmptySets}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  actions.setHideEmpty(!hideEmpty);
+                }
+              }}
+            >
               <FormControlLabel
                 sx={{ ml: 0, '& span': { fontSize: '0.8rem' } }}
                 label="Hide Empty Intersections"
@@ -236,8 +274,16 @@ export const Sidebar = () => {
                 labelPlacement="start"
               />
               <HelpCircle text={helpText.filter.HideEmptySets} margin={{ ...defaultMargin, left: 12 }} />
-            </div>
-            <div css={itemDivCSS}>
+            </Box>
+            <Box
+              css={itemDivCSS}
+              aria-label={helpText.filter.HideNoSet}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  actions.setHideNoSet(!hideNoSet);
+                }
+              }}
+            >
               <FormControlLabel
                 sx={{ ml: 0, '& span': { fontSize: '0.8rem' } }}
                 label="Hide No-Set Intersection"
@@ -253,16 +299,21 @@ export const Sidebar = () => {
                 labelPlacement="start"
               />
               <HelpCircle text={helpText.filter.HideNoSet} margin={{ ...defaultMargin, left: 12 }} />
-            </div>
+            </Box>
           </FormGroup>
           <FormGroup>
-            <div css={itemDivCSS}>
+            <Box
+              css={itemDivCSS}
+            >
               <FormLabel>
                 <Typography>Filter by Degree</Typography>
               </FormLabel>
               <HelpCircle text={helpText.filter.Degree} />
-            </div>
-            <div css={itemDivCSS}>
+            </Box>
+            <Box
+              css={itemDivCSS}
+              aria-label={helpText.filter.Degree}
+            >
               <Slider
                 value={degreeFilters}
                 min={0}
@@ -280,7 +331,7 @@ export const Sidebar = () => {
                   actions.setMaxVisible(degreeFilters[1]);
                 }}
               />
-            </div>
+            </Box>
           </FormGroup>
         </AccordionDetails>
       </Accordion>

--- a/packages/upset/src/components/custom/HelpCircle.tsx
+++ b/packages/upset/src/components/custom/HelpCircle.tsx
@@ -28,6 +28,7 @@ export const HelpCircle = ({ text, margin = { ...defaultMargin }, size = 13 }: {
         padding: '3px',
       }}
       disableTouchRipple
+      aria-hidden
     >
       <QuestionMark sx={{ height: size, width: size }} />
     </IconButton>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #275 
Closes #265 

### Give a longer description of what this PR addresses and why it's needed
This PR adds `aria-label` tags to MANY elements in which a screen reader was not able to easily discern what the item/group is. This was tested with MacOS voiceover and a very limited understanding of screenreader usage. Tags such as `aria-haspopup` were used to notate items which cause popup actions. 

Additionally, some sidebar elements such as the sorting and aggregation radio buttons were consolidated into more succinct groups (from the screenreader perspective) using `aria-hidden`, `aria-label`, and adding keypress listeners for better flow when tabbing through the application.

When importing an UpSet config state file, there were errors possible (wrong file type, etc), but these were invisible to a screenreader. `aria-errormessage` was added to the importer so that the `Snackbar` alerts would properly read when an import error occurred.

Also, the footer button configuration was altered so that there is no more custom element. The nature of the custom JSX element was causing issues with aria-label and nested group elements so the flow was not consistent for a screenreader. Instead, the buttons were just made into their respective semantic elements.

Also, the default configuration had both the alt-text and element view sidebar open at instantiation. Now, there are no sidebars open on-load.


---

Here are some assorted notes I took on aria tags while drafting this PR:


### Notes for aria tags:

It is very important to be deliberate about where/when aria tags are used. Where HTML semantics suffice, use those instead.

`aria-haspopup`: `menu`, `listbox`, `tree`, `grid`, `dialog`, or `true`. Should we include this on buttons which open sidebars (show alt-text, Element View, etc)?

For elements like menu, the MUI elements (ie `<Menu>` , `<MenuItem>`) automatically have their respective roles applied, so this should not be overwritten

aria-label: this should be applied to any action which does not have a semantic label, or is not clear from the name/label of the element. This should also be used for any link navigation (aka. “Send email to VDL faculty” rather than `vdl-faculty@sci.utah.edu`)

`aria-errormessage`: should be put on any action which may trigger a user-readable error (i.e: importing an invalid UpSet state)

`aria-live/aria-relevant`: this can be used to declare that an element has updated. `polite` will not interrupt the current reader queue, while `assertive` will. `aria-relevant` dictates which updates should trigger the `aria-live` announcement. These can be `additions`, `removals`, `text`, `all`, or some combination. I’m unsure of how to add this to a modal or similar to indicate that it has been opened. Ideally for something like importing state, there should be an announcement to the screenreader post-import, but triggering this event may prove difficult as it doesn’t really add or remove any text or HTML elements. It could be possible to put a hidden element with the time of the last import and updating the import could alter the text, triggering the event. My concern with this method is that hacking around aria seems to be problematic at best.

`role`: this can be problematic at times, because this affects semantic context for some screenreaders when used incorrectly. However, for something like MUI’s Alert component, the info alert is being used as a styled information box. Since these have the role alert, screenreaders will read these on any update, if they are rendered and visible. To get around this while using the styling from the info alert, the role can be changed to generic. Since there is no real semantic context for the `infobox`, using the generic role makes sense, and eliminates unwanted behavior, such as reading the text any time there is a screen update.

---

### Provide pictures/videos of the behavior before and after these changes (optional)
There should be no visual change

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] _MAYBE_ add aria-live updates to modals, sidebars, and menus on open. I'm not sure exactly how this works, or even if it is supposed to happen for these elements.