### PR TITLE
Update grammar to include set sizes under "allSets"

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,8 @@ import { DataTable } from './components/DataTable';
 /** @jsxImportSource @emotion/react */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
+const defaultVisibleSets = 6;
+
 function App() {
   const multinetData = useRecoilValue(dataSelector);
   const encodedData = useRecoilValue(encodedDataAtom);
@@ -27,11 +29,11 @@ function App() {
     if (data !== null) {
       const conf = JSON.parse(JSON.stringify(config))
       if (config.visibleSets.length === 0) {
-        const setList = Object.keys(data.sets);
-        conf.visibleSets = setList.slice(0, 6);
-        conf.allSets = setList;
+        const setList = Object.entries(data.sets);
+        conf.visibleSets = setList.slice(0, defaultVisibleSets).map((set) => set[0]) // get first 6 set names
+        conf.allSets = setList.map((set) => {return { name: set[0], size: set[1].size }})
       }
-      
+
       conf.visibleAttributes = data.attributeColumns.slice(0, 3);
 
       return conf;

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import { exportState, getAccessibleData, downloadSVG } from '@visdesignlab/upset2-react';
-import { getRows } from '@visdesignlab/upset2-core';
+import { Column, getRows } from '@visdesignlab/upset2-core';
 import { UserSpec } from 'multinet';
 import RedoIcon from '@mui/icons-material/Redo';
 import UndoIcon from '@mui/icons-material/Undo';
@@ -38,7 +38,7 @@ const Header = ({ data }: { data: any }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
   
   const visibleSets = provenance.getState().visibleSets;
-  const hiddenSets = provenance.getState().allSets.filter((set: string) => !visibleSets.includes(set));
+  const hiddenSets = provenance.getState().allSets.filter((set: Column) => !visibleSets.includes(set.name));
 
   const handleImportModalClose = () => {
     setShowImportModal(false);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,10 @@
 export type ColumnName = string;
 
+export type Column = {
+  name: string,
+  size: number
+};
+
 export type ColumnDefs = {
   [columnName: string]: 'number' | 'boolean' | 'string' | 'label';
 };
@@ -176,7 +181,7 @@ export type UpsetConfig = {
     histograms: Histogram[];
     wordClouds: WordCloud[];
   };
-  allSets: ColumnName[];
+  allSets: Column[];
 };
 
 export type AccessibleDataEntry = {

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -53,9 +53,9 @@ export const Upset: FC<UpsetProps> = ({
     const conf: UpsetConfig = { ...defaultConfig, ...config };
 
     if (conf.visibleSets.length === 0) {
-      const setList = Object.keys(data.sets);
-      conf.visibleSets = setList.slice(0, defaultVisibleSets);
-      conf.allSets = setList;
+      const setList = Object.entries(data.sets);
+      conf.visibleSets = setList.slice(0, defaultVisibleSets).map((set) => set[0]); // get first 6 set names
+      conf.allSets = setList.map((set) => ({ name: set[0], size: set[1].size }));
     }
 
     conf.visibleAttributes = data.attributeColumns.slice(0, loadAttributes);


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #284 

### Give a longer description of what this PR addresses and why it's needed
This PR adds set size information to `allSets` in the UpSet grammar. This is useful because currently the only way for setSize to be obtained via the grammar is to parse the rawData entry.

The `visibleSets` entry remains the same (list of names), as all visible sets are included under `allSets`.

Here is an example of the new `allSets` field:
```json
"allSets": [
    {
      "name": "Set_School",
      "size": 6
    },
    {
      "name": "Set_Blue_Hair",
      "size": 3
    },
    {
      "name": "Set_Duff_Fan",
      "size": 6
    },
    {
      "name": "Set_Evil",
      "size": 6
    },
    {
      "name": "Set_Male",
      "size": 18
    },
    {
      "name": "Set_Power_Plant",
      "size": 5
    }
  ]
```

*NOTE:* Anywhere that `allSets` is being used in applications which use the grammar will require updates to utilize newly generated grammar.

@elizaan upset-alt-txt can be updated accordingly to no longer use rawData if possible

### Provide pictures/videos of the behavior before and after these changes (optional)
No changes to user interaction or app behavior

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] note changes to alt-text required 