### PR TITLE
Patch: datatable hiddensets dispatch wrong object type

### DIFF
--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -100,7 +100,7 @@ const Header = ({ data }: { data: any }) => {
     localStorage.setItem('data', JSON.stringify(data));
     localStorage.setItem('rows', JSON.stringify(getAccessibleData(getRows(data, provenance.getState()), true)));
     localStorage.setItem('visibleSets', JSON.stringify(visibleSets));
-    localStorage.setItem('hiddenSets', JSON.stringify(hiddenSets));
+    localStorage.setItem('hiddenSets', JSON.stringify(hiddenSets.map((set: Column) => set.name)));
     saveQueryParam();
   };
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
Patch for datatable being broken due to invalid operation.

Hidden Sets was being saved in localStorage as a dict with name and size, but it needed to be a list of strings.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...