### PR TITLE
Add Horziontal grammar flag, refactor defaultConfig

### DIFF
--- a/packages/app/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/app/src/atoms/config/upsetConfigAtoms.ts
@@ -1,38 +1,10 @@
-import { UpsetConfig } from '@visdesignlab/upset2-core';
+import { UpsetConfig, DefaultConfig } from '@visdesignlab/upset2-core';
 import { atom } from 'recoil';
 
-export const defaultConfig: UpsetConfig = {
-  plotInformation: {
-    description: '',
-    sets: '',
-    items: '',
-  },
-  firstAggregateBy: 'None',
-  firstOverlapDegree: 2,
-  secondAggregateBy: 'None',
-  secondOverlapDegree: 2,
-  sortVisibleBy: 'Alphabetical',
-  sortBy: 'Size',
-  sortByOrder: 'Descending',
-  filters: {
-    maxVisible: 3,
-    minVisible: 0,
-    hideEmpty: true,
-    hideNoSet: false,
-  },
-  visibleSets: [],
-  visibleAttributes: [],
-  bookmarkedIntersections: [],
-  collapsed: [],
-  plots: {
-    scatterplots: [],
-    histograms: [],
-    wordClouds: [],
-  },
-  allSets: [],
-};
+// fields can be edited here to stray from default config
+const config = { ...DefaultConfig };
 
 export const upsetConfigAtom = atom<UpsetConfig>({
   key: 'app-config',
-  default: defaultConfig,
+  default: config,
 });

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -15,7 +15,7 @@ export const DefaultConfig: UpsetConfig = {
   sortBy: 'Size',
   sortByOrder: 'Descending',
   filters: {
-    maxVisible: 3,
+    maxVisible: 6,
     minVisible: 0,
     hideEmpty: true,
     hideNoSet: false,

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -1,0 +1,33 @@
+import { UpsetConfig } from './types';
+
+export const DefaultConfig: UpsetConfig = {
+  plotInformation: {
+    description: '',
+    sets: '',
+    items: '',
+  },
+  horizontal: false,
+  firstAggregateBy: 'None',
+  firstOverlapDegree: 2,
+  secondAggregateBy: 'None',
+  secondOverlapDegree: 2,
+  sortVisibleBy: 'Alphabetical',
+  sortBy: 'Size',
+  sortByOrder: 'Descending',
+  filters: {
+    maxVisible: 3,
+    minVisible: 0,
+    hideEmpty: true,
+    hideNoSet: false,
+  },
+  visibleSets: [],
+  visibleAttributes: [],
+  bookmarkedIntersections: [],
+  collapsed: [],
+  plots: {
+    scatterplots: [],
+    histograms: [],
+    wordClouds: [],
+  },
+  allSets: [],
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,4 @@ export * from './aggregate';
 export * from './sort';
 export * from './filter';
 export * from './render';
+export * from './defaultConfig';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,12 +1,16 @@
 export type ColumnName = string;
 
 export type Column = {
-  name: string,
-  size: number
+  name: string;
+  size: number;
 };
 
 export type ColumnDefs = {
   [columnName: string]: 'number' | 'boolean' | 'string' | 'label';
+};
+
+export type Meta = {
+  columns: ColumnDefs;
 };
 
 export type PlotInformation = {
@@ -161,6 +165,7 @@ export type Bookmark = { id: string; label: string; size: number }
 
 export type UpsetConfig = {
   plotInformation: PlotInformation;
+  horizontal: boolean;
   firstAggregateBy: AggregateBy;
   firstOverlapDegree: number;
   secondAggregateBy: AggregateBy;

--- a/packages/upset/src/atoms/config/upsetConfigAtoms.ts
+++ b/packages/upset/src/atoms/config/upsetConfigAtoms.ts
@@ -1,39 +1,8 @@
-import { UpsetConfig } from '@visdesignlab/upset2-core';
+import { UpsetConfig, DefaultConfig } from '@visdesignlab/upset2-core';
 import { atom } from 'recoil';
 
 // This config is overruled by any config provided by an external source
-export const defaultConfig: UpsetConfig = {
-  plotInformation: {
-    description: '',
-    sets: '',
-    items: '',
-  },
-  firstAggregateBy: 'None',
-  firstOverlapDegree: 2,
-  secondAggregateBy: 'None',
-  secondOverlapDegree: 2,
-  sortVisibleBy: 'Alphabetical',
-  sortBy: 'Size',
-  sortByOrder: 'Descending',
-  filters: {
-    maxVisible: 3,
-    minVisible: 0,
-    hideEmpty: true,
-    hideNoSet: false,
-  },
-  visibleSets: [],
-  visibleAttributes: [],
-  bookmarkedIntersections: [],
-  collapsed: [],
-  plots: {
-    scatterplots: [],
-    histograms: [],
-    wordClouds: [],
-  },
-  allSets: [],
-};
-
 export const upsetConfigAtom = atom<UpsetConfig>({
   key: 'upset-config',
-  default: defaultConfig,
+  default: DefaultConfig,
 });

--- a/packages/upset/src/atoms/provenanceAtom.ts
+++ b/packages/upset/src/atoms/provenanceAtom.ts
@@ -1,9 +1,7 @@
-import { UpsetConfig } from '@visdesignlab/upset2-core';
+import { UpsetConfig, DefaultConfig } from '@visdesignlab/upset2-core';
 import { atom } from 'recoil';
-
-import { defaultConfig } from './config/upsetConfigAtoms';
 
 export const stateAtom = atom<UpsetConfig>({
   key: 'upset-state',
-  default: defaultConfig,
+  default: DefaultConfig,
 });

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -3,7 +3,6 @@ import { CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
 import { FC, useMemo } from 'react';
 import { RecoilRoot } from 'recoil';
 
-import { defaultConfig } from '../atoms/config/upsetConfigAtoms';
 import { UpsetActions, UpsetProvenance } from '../provenance';
 import defaultTheme from '../utils/theme';
 import { Root } from './Root';

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -1,5 +1,5 @@
 import { Box, ThemeProvider } from '@mui/material';
-import { CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
+import { CoreUpsetData, UpsetConfig, DefaultConfig } from '@visdesignlab/upset2-core';
 import { FC, useMemo } from 'react';
 import { RecoilRoot } from 'recoil';
 
@@ -49,7 +49,7 @@ export const Upset: FC<UpsetProps> = ({
   // Combine the partial config and add visible sets if empty
   // Also add missing attributes if specified
   const combinedConfig = useMemo(() => {
-    const conf: UpsetConfig = { ...defaultConfig, ...config };
+    const conf: UpsetConfig = { ...DefaultConfig, ...config };
 
     if (conf.visibleSets.length === 0) {
       const setList = Object.entries(data.sets);

--- a/packages/upset/src/index.tsx
+++ b/packages/upset/src/index.tsx
@@ -10,7 +10,6 @@ export {
 
 export {
   upsetConfigAtom,
-  defaultConfig,
 } from './atoms/config/upsetConfigAtoms';
 
 export * from './utils/downloads';

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {
-  AggregateBy, Plot, PlotInformation, SortBy, SortByOrder, SortVisibleBy, UpsetConfig,
+  AggregateBy, Plot, PlotInformation, SortBy, SortByOrder, SortVisibleBy, UpsetConfig, DefaultConfig,
 } from '@visdesignlab/upset2-core';
 
 import { Registry, initializeTrrack } from '@trrack/core';
-import { defaultConfig } from '../atoms/config/upsetConfigAtoms';
 
 export type Metadata = {
   [key: string]: unknown;
@@ -302,7 +301,7 @@ export function initializeProvenanceTracking(
   config: Partial<UpsetConfig> = {},
   setter?: (state: UpsetConfig) => void,
 ) {
-  const finalConfig: UpsetConfig = { ...defaultConfig, ...config };
+  const finalConfig: UpsetConfig = { ...DefaultConfig, ...config };
 
   const provenance = initializeTrrack(
     { initialState: finalConfig, registry },
@@ -326,7 +325,7 @@ export function getActions(provenance: UpsetProvenance) {
     secondAggregateBy: (aggBy: AggregateBy) => provenance.apply(`Second aggregate by ${aggBy}`, secondAggAction(aggBy)),
     secondOverlapBy: (overlap: number) => provenance.apply(`Second overlap by ${overlap}`, secondOverlapAction(overlap)),
     sortVisibleBy: (sort: SortVisibleBy) => provenance.apply(`Sort Visible Sets by ${sort}`, sortVisibleSetsAction(sort)),
-    sortBy: (sort: SortBy, sortByOrder: SortByOrder) => provenance.apply(`Sort by ${sort}, ${sortByOrder}`, sortByAction({sort, sortByOrder})),
+    sortBy: (sort: SortBy, sortByOrder: SortByOrder) => provenance.apply(`Sort by ${sort}, ${sortByOrder}`, sortByAction({ sort, sortByOrder })),
     setMaxVisible: (val: number) => provenance.apply(`Hide intersections above ${val}`, maxVisibleAction(val)),
     setMinVisible: (val: number) => provenance.apply(`Hide intersections below ${val}`, minVisibleAction(val)),
     setHideEmpty: (val: boolean) => provenance.apply(val ? 'Hide empty intersections' : 'Show empty intersections', hideEmptyAction(val)),


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #298 

### Give a longer description of what this PR addresses and why it's needed
This PR adds a horizontal flag to the grammar (default: false). This is meant for alt-text for horizontal plots. UpSet2 should never set this value to false unless a horizontal implementation is added.

Additionally, this PR refactors the `DefaultConfig` to improve DRY principles. By moving this to Core, the defaultConfig can be imported as an object. This means it is defined in only one location and is easily changed.

This PR has no effect on behavior of the app or alt-txt.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...