### PR TITLE
Update alt-text generation hook to depend on the currentState

### DIFF
--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -18,8 +18,6 @@ import {
 } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Edit } from '@mui/icons-material';
-import { sortBySelector } from '../atoms/config/sortByAtom';
-import { maxVisibleSelector, minVisibleSelector } from '../atoms/config/filterAtoms';
 import { ProvenanceContext } from './Root';
 import { plotInformationSelector } from '../atoms/config/plotInformationAtom';
 import ReactMarkdownWrapper from './custom/ReactMarkdownWrapper';
@@ -48,12 +46,10 @@ const plotInfoTitle = {
 const initialDrawerWidth = 450;
 
 export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
-  const { actions } = useContext(ProvenanceContext);
+  const { provenance, actions } = useContext(ProvenanceContext);
   const plotInformationState = useRecoilValue(plotInformationSelector);
 
-  const sort = useRecoilValue(sortBySelector);
-  const minVisible = useRecoilValue(minVisibleSelector);
-  const maxVisible = useRecoilValue(maxVisibleSelector);
+  const currState = provenance.getState();
 
   const [textDescription, setTextDescription] = useState('');
   const [isEditable, setIsEditable] = useState(false);
@@ -76,7 +72,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
     }
 
     generate();
-  }, [sort, minVisible, maxVisible]);
+  }, [currState]);
 
   // this useEffect resets the plot information when the edit is toggled off
   useEffect(() => {

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -21,6 +21,7 @@ import { Edit } from '@mui/icons-material';
 import { ProvenanceContext } from './Root';
 import { plotInformationSelector } from '../atoms/config/plotInformationAtom';
 import ReactMarkdownWrapper from './custom/ReactMarkdownWrapper';
+import { upsetConfigAtom } from '../atoms/config/upsetConfigAtoms';
 
 type Props = {
   open: boolean;
@@ -46,10 +47,10 @@ const plotInfoTitle = {
 const initialDrawerWidth = 450;
 
 export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
-  const { provenance, actions } = useContext(ProvenanceContext);
+  const { actions } = useContext(ProvenanceContext);
   const plotInformationState = useRecoilValue(plotInformationSelector);
 
-  const currState = provenance.getState();
+  const currState = useRecoilValue(upsetConfigAtom);
 
   const [textDescription, setTextDescription] = useState('');
   const [isEditable, setIsEditable] = useState(false);
@@ -71,7 +72,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       setTextDescription(resp);
     }
 
-    if (currState.aggregateBy === 'None') {
+    if (currState.firstAggregateBy === 'None') {
       generate();
     }
   }, [currState]);

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -71,7 +71,9 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       setTextDescription(resp);
     }
 
-    generate();
+    if (currState.aggregateBy === 'None') {
+      generate();
+    }
   }, [currState]);
 
   // this useEffect resets the plot information when the edit is toggled off


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #305 

### Give a longer description of what this PR addresses and why it's needed
Previously, the alt-text hook needed to be adjusted to include all possible changes which could trigger re-generation. By using the current state as the hook dependency, any state update will cause regeneration.

If the alt-text is ever stored in the state, this may need to be adjusted to accommodate that.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
