### PR TITLE
Fix display name for intersections in element sidebar

### DIFF
--- a/packages/upset/src/components/ElementView/ElementQueries.tsx
+++ b/packages/upset/src/components/ElementView/ElementQueries.tsx
@@ -25,6 +25,7 @@ export const ElementQueries = () => {
   const data = useRecoilValue(dataAtom);
   const rows = flattenedOnlyRows(data, provenance.getState());
   const bookmarked = useRecoilValue(bookmarkedIntersectionSelector);
+  const currentIntersectionDisplayName = currentIntersection?.elementName.replaceAll("~&~", " & ") || "";
 
   return (
     <>
@@ -87,21 +88,21 @@ export const ElementQueries = () => {
             backgroundColor: 'rgba(0,0,0,0.2)',
           })}
           icon={<SquareIcon fontSize={'1em' as any} />}
-          aria-label={`Selected intersection ${currentIntersection.elementName}, size ${currentIntersection.size}`}
+          aria-label={`Selected intersection ${currentIntersectionDisplayName}, size ${currentIntersection.size}`}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               actions.bookmarkIntersection(
                 currentIntersection.id,
-                currentIntersection.elementName,
+                currentIntersectionDisplayName,
                 currentIntersection.size,
               );
             }
           }}
-          label={`${currentIntersection.elementName} - ${currentIntersection.size}`}
+          label={`${currentIntersectionDisplayName} - ${currentIntersection.size}`}
           onDelete={() => {
             actions.bookmarkIntersection(
               currentIntersection.id,
-              currentIntersection.elementName,
+              currentIntersectionDisplayName,
               currentIntersection.size,
             );
           }}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #311 

### Give a longer description of what this PR addresses and why it's needed
This fix replaces the `~&~` delimiter between set names in subset labels with a more readable ` & ` by creating a selected element display name, using it instead of the intersection name, and passing it to the bookmark function. 

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [ x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
No