### PR TITLE
Bugfix: no Trrack action for unchanged filters

### DIFF
--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -71,6 +71,8 @@ export const Sidebar = () => {
   );
 
   const [degreeFilters, setDegreeFilters] = useState([minVisible, maxVisible]);
+  // Tracking the previous state of the filters to avoid unnecessary updates
+  const [prevFilters, setPrevFilters] = useState([minVisible, maxVisible]);
 
   useEffect(() => {
     if (firstAggregateBy === 'None') {
@@ -286,8 +288,14 @@ export const Sidebar = () => {
                   }
                 }}
                 onChangeCommitted={() => {
-                  actions.setMinVisible(degreeFilters[0]);
-                  actions.setMaxVisible(degreeFilters[1]);
+                  // Prevents unncessary Trrack state changes
+                  if (prevFilters[0] !== degreeFilters[0]) {
+                    actions.setMinVisible(degreeFilters[0]);
+                  }
+                  if (prevFilters[1] !== degreeFilters[1]) {
+                    actions.setMaxVisible(degreeFilters[1]);
+                  }
+                  setPrevFilters(degreeFilters);
                 }}
               />
             </Box>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #306 

### Give a longer description of what this PR addresses and why it's needed
Previously, moving the degree filter slider around and returning it to its original position dispatched a trrack action to the provenance graph despite no change being made. In addition, changing only the lower or upper bound would dispatch an action for the unchanged bound. This fixes both issues by only dispatching actions for changed bounds after the slider is released.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
