### PR TITLE
Ensure UpSet table always scrolls horizontally when needed

### DIFF
--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -67,7 +67,7 @@ export const Body = ({ yOffset, data, config }: Props) => {
   }
 
   return (
-    <div>
+    <div style={{maxWidth: "100vw"}}>
       { data.setColumns.length === 0 ?
         <ErrorModal />:
         <Upset


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #286 

### Give a longer description of what this PR addresses and why it's needed
Previously, the UpSet table behaved as though it had `overflow: hidden` (in reality, it was simply expanding off the screen & not viewable). By setting a max-width for the body element, the table becomes horizontally scrollable, addressing the issue of sidebars covering the table contents.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
