### PR TITLE
Remove `getId` call from set id generation

### DIFF
--- a/e2e-tests/datatable.spec.ts
+++ b/e2e-tests/datatable.spec.ts
@@ -74,7 +74,7 @@ test('Datatable', async ({ page }) => {
   // //////////////////
   const datatable = await page1.getByText('IntersectionSizeSchool & Male3Unincluded3Male3Duff Fan & Male & Power Plant3Evil & Male2Evil & Male & Power Plant2Duff Fan & Male2Blue Hair2School1School & Evil & Male1Rows per page:101–10 of');
   await expect(datatable).toBeVisible();
-  const visibleSets = await page1.getByText('SetSizeSchool6Blue_Hair3Duff_Fan6Evil6Male18Power_Plant5Rows per page:101–6 of');
+  const visibleSets = await page1.getByText('SetSizeSchool6Blue Hair3Duff Fan6Evil6Male18Power Plant5Rows per page:101–6 of');
   await expect(visibleSets).toBeVisible();
   const hiddenSets = await page1.getByText('No rowsSetSizeRows per page:100–0 of');
   await expect(hiddenSets).toBeVisible();

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -216,7 +216,7 @@ function getSets(
   const sets: Sets = {};
   setColumns.forEach((col) => {
     const set: ISet = {
-      id: getId('Set', col),
+      id: `Set_${col}`,
       elementName: col,
       items: setMembership[col],
       type: 'Set',


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #322 

### Give a longer description of what this PR addresses and why it's needed
This PR removes the `getId` call from the set's id generation to remove any interference with existing set names. The `_` filtering isn't being used anywhere, and so this can be entirely removed.

### Provide pictures/videos of the behavior before and after these changes (optional)
#### Old alt-text:
![image](https://github.com/visdesignlab/upset2/assets/35744963/8494b19f-fa64-4604-8fea-6db6a324c0c9)

#### Updated alt-text:
![image](https://github.com/visdesignlab/upset2/assets/35744963/973da2b8-d074-4e1d-b283-346f4a397ee1)

#### Old data-table (visible sets):
![image](https://github.com/visdesignlab/upset2/assets/35744963/280a6c6e-932b-4645-976a-3f375755baa9)

#### Update data-table (visible sets):
![image](https://github.com/visdesignlab/upset2/assets/35744963/83f66df8-d321-4043-b305-735d2682bc25)


### Have you added or updated relevant tests?
- [X] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- None
