### PR TITLE
Add error handling for alt text API

### DIFF
--- a/e2e-tests/alttext.spec.ts
+++ b/e2e-tests/alttext.spec.ts
@@ -59,6 +59,12 @@ test('Alt Text', async ({ page }) => {
   await expect(plotInformation).toBeVisible();
   await plotInformation.click();
 
+  // Test error message for aggregated plots
+  await page.getByRole('radio', { name: 'Degree' }).check();
+  const aggErrMsg = await page.getByText("Alt text generation is not yet supported for aggregated plots. To generate an alt text, set aggregation to 'None' in the left sidebar.");
+  await expect(aggErrMsg).toBeVisible();
+  await page.getByRole('radio', { name: 'None' }).check();
+
   const editPlotInformationButton = await page.getByLabel('Toggle editable descriptions');
   await expect(editPlotInformationButton).toBeVisible();
   await editPlotInformationButton.click();

--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -47,11 +47,33 @@ export const Body = ({ yOffset, data, config }: Props) => {
     })
   }, [provObject.provenance, sessionId, workspace]);
 
-  async function generateAltText() {
+  /**
+   * Generates alt text for a plot based on the current state and configuration.
+   * If an error occurs during the generation, an error message is returned.
+   * Alt text generation currently is not supported for aggregated plots
+   * and an error message is returned if the plot is aggregated.
+   * @returns A promise that resolves to the generated alt text.
+   */
+  async function generateAltText(): Promise<string> {
     const state = provObject.provenance.getState();
     const config = getAltTextConfig(state, data, getRows(data, state));
 
-    const response = await api.generateAltText(true, config);
+    if (config.firstAggregateBy !== "None") {
+      return "Alt text generation is not yet supported for aggregated plots. To generate an alt text, set aggregation to 'None' in the left sidebar.";
+    }
+
+    let response;
+    try {
+      response = await api.generateAltText(true, config);
+    } catch (e: any) {
+      if (e.response.status === 500) {
+        return "Server error while generating alt text. Please try again later. If the issue persists, please contact an UpSet developer at vdl-faculty@sci.utah.edu.";
+      } else if (e.response.status === 400) {
+        return "Error generating alt text. Contact an upset developer at vdl-faculty@sci.utah.edu.";
+      } else {
+        return "Unknown error while generating alt text: " + e.response.statusText + ". Please contact an UpSet developer at vdl-faculty@sci.utah.edu.";
+      }
+    }
     return response.alttxt.longDescription;
   }
 

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -72,9 +72,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       setTextDescription(resp);
     }
 
-    if (currState.firstAggregateBy === 'None') {
-      generate();
-    }
+    generate();
   }, [currState]);
 
   // this useEffect resets the plot information when the edit is toggled off


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #324 

### Give a longer description of what this PR addresses and why it's needed
This PR adds error handling for aggregated plots which we can't generate alttxts for. Previously, Upset would silently refuse to update an alttxt for an aggregated plot without informing the user. Now, an error message is displayed when attempting to generate an alttxt for an aggregated plot. Additionally, more error handling was added for errors from the alttxt API; appropriate error messages are displayed if the API fails with a 400 code, 500 code, or other code. Finally, a test was added to Playwright to ensure that the error message displays for aggregated alttxt generation.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="2053" alt="Screenshot 2024-03-28 at 10 01 53 PM" src="https://github.com/visdesignlab/upset2/assets/58234814/9e0013e3-ec8c-4b0a-ab9b-08814c885d0e">
After:
<img width="2053" alt="Screenshot 2024-03-28 at 10 02 21 PM" src="https://github.com/visdesignlab/upset2/assets/58234814/6da33409-2404-45db-8488-ed9dec0f0cbf">


### Have you added or updated relevant tests?
- [X] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
