### PR TITLE
Hide title on narrower screens

### DIFF
--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -153,7 +153,7 @@ const Header = ({ data }: { data: any }) => {
       }}>
         <Box sx={{display: 'flex', flexGrow: '1', justifyContent: 'start', alignItems: 'center', margin: 0, padding: 0}}>
           <img className="logo" id="multinet-logo" src="https://raw.githubusercontent.com/multinet-app/multinet-components/main/src/assets/multinet_logo.svg" alt="Multinet Logo"/>
-          <Typography variant="h1" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal', fontSize: '1.3em' }}>
+          <Typography id="upset-title" variant="h1" noWrap component="div" sx={{ marginRight: '5px', lineHeight: '1.5', fontWeight: 'normal', fontSize: '1.3em' }}>
             Upset - Visualizing Intersecting Sets
           </Typography>
           <ButtonGroup>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -18,6 +18,7 @@ code {
   margin-right: 10px;
 }
 
+/* Ensure that the Upset title is hidden on smaller screens to not compete with other menu bar items */
 @media only screen and (max-width: 1060px) {
   #upset-title {
     display: none;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -17,3 +17,9 @@ code {
   width: 32px;
   margin-right: 10px;
 }
+
+@media only screen and (max-width: 1060px) {
+  #upset-title {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #335 

### Give a longer description of what this PR addresses and why it's needed
The UpSet title competes with the menu bar items on smaller screen widths and needs to be hidden to give the rest of the menu space.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before: 
![335-before](https://github.com/visdesignlab/upset2/assets/58234814/7ad724ad-3148-46a0-80aa-7310cd347679)
After:
![335-after](https://github.com/visdesignlab/upset2/assets/58234814/30896639-fab1-41fc-8bc6-63f3fc782dbc)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
No
