### PR TITLE
Ensure overlap degree pickers don't produce duplicate Trrack actions

### DIFF
--- a/e2e-tests/provenance.spec.ts
+++ b/e2e-tests/provenance.spec.ts
@@ -79,3 +79,52 @@ test('Selection History', async ({ page }) => {
   await expect(page.getByText('Bookmark Duff Fan & Male', { exact: true })).toBeVisible();
   await expect(page.getByText('Select intersection "Duff Fan')).toBeVisible();
 });
+
+/**
+ * Tests that overlap history works 
+ * & doesn't produce duplicate actions when the overlap degree is changed to the same value
+ */
+test('Overlap History', async ({ page }) => {
+  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+  await page.getByLabel('Open additional options menu').click();
+  await page.getByLabel('Open history tree sidebar').click();
+  
+  // Ensure that duplicate actions aren't recorded for decreasing first degree
+  await page.getByRole('radio', { name: 'Overlaps' }).check();
+  await page.getByRole('spinbutton', { name: 'Degree' }).click();
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowDown');
+  await expect(page.getByText('First overlap by 2')).toHaveCount(0);
+
+  // Try to increment degree to 7 (limit is 6); confirm no duplicate at any level
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await expect(page.getByText('First overlap by 3')).toHaveCount(1);
+  await expect(page.getByText('First overlap by 4')).toHaveCount(1);
+  await expect(page.getByText('First overlap by 5')).toHaveCount(1);
+  await expect(page.getByText('First overlap by 6')).toHaveCount(1);
+
+  // Switch to second aggregation by overlap
+  await page.getByRole('radio', { name: 'Deviations' }).check();
+  await page.getByRole('button', { name: 'Second Aggregation' }).click();
+  await page.locator('div').filter({ hasText: /^Second AggregationDegreeSetsOverlapsNone$/ })
+    .getByLabel('Overlaps', { exact: true }).check();
+  await page.getByRole('spinbutton', { name: 'Degree' }).click();
+  
+  // Ensure no duplicate action for decreasing 2nd degree
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowDown');
+  await expect(page.getByText('Second overlap by 2')).toHaveCount(0);
+  
+  // Try to increment degree to 7; confirm no duplicates
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await page.getByRole('spinbutton', { name: 'Degree' }).press('ArrowUp');
+  await expect(page.getByText('Second overlap by 3')).toHaveCount(1);
+  await expect(page.getByText('Second overlap by 4')).toHaveCount(1);
+  await expect(page.getByText('Second overlap by 5')).toHaveCount(1);
+  await expect(page.getByText('Second overlap by 6')).toHaveCount(1);
+})

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -133,6 +133,7 @@ export const Sidebar = () => {
                         let val = parseInt(ev.target.value, 10);
                         if (val < 2) val = 2;
                         if (val > visibleSets.length) val = visibleSets.length;
+                        if (val === firstOverlapDegree) return; // Don't dispatch action if overlap hasn't changed
                         actions.firstOverlapBy(val);
                       }}
                     />
@@ -195,6 +196,7 @@ export const Sidebar = () => {
                           let val = parseInt(ev.target.value, 10);
                           if (val < 2) val = 2;
                           if (val > visibleSets.length) val = visibleSets.length;
+                          if (val === secondOverlapDegree) return; // Don't dispatch an action if overlap hasn't changed
                           actions.secondOverlapBy(val);
                         }}
                       />

--- a/packages/upset/src/components/Sidebar.tsx
+++ b/packages/upset/src/components/Sidebar.tsx
@@ -131,6 +131,7 @@ export const Sidebar = () => {
                       value={firstOverlapDegree}
                       onChange={(ev) => {
                         let val = parseInt(ev.target.value, 10);
+                        if (!val) return; // Blocks users from clearing the input
                         if (val < 2) val = 2;
                         if (val > visibleSets.length) val = visibleSets.length;
                         if (val === firstOverlapDegree) return; // Don't dispatch action if overlap hasn't changed
@@ -194,6 +195,7 @@ export const Sidebar = () => {
                         value={secondOverlapDegree}
                         onChange={(ev) => {
                           let val = parseInt(ev.target.value, 10);
+                          if (!val) return; // Block users from clearing the input
                           if (val < 2) val = 2;
                           if (val > visibleSets.length) val = visibleSets.length;
                           if (val === secondOverlapDegree) return; // Don't dispatch an action if overlap hasn't changed


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #309 

### Give a longer description of what this PR addresses and why it's needed
Previously, when overlap was set as the first or second aggregation, decrementing the overlap degree while at its minimum (2) or maximum value would produce duplicate `[First/Second] Overlap Degree` actions in Trrack; Trrack would record a new overlap degree despite the degree being unchanged. This fixes that bug: now, a Trrack action is only recorded if the overlap degree changes.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before: 
![309-before](https://github.com/visdesignlab/upset2/assets/58234814/ee45133e-6ee0-4f7d-a528-0cac69cb30c3)
After:
![309-after](https://github.com/visdesignlab/upset2/assets/58234814/519efd5a-7e88-4cd6-8a5a-d27f05945bbb)


### Have you added or updated relevant tests?
- [X] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Confirm functionality: Currently, when the user first or second aggregates by overlap for the first time, the degree is set to 2, but no Trrack action is recorded for setting the first/second overlap degree to 2. This can result in a plot aggregated by overlap degree 2 with no Trrack action to indicate the overlap degree. Once the overlap degree has been edited, it maintains its state through changes to aggregation, so re-aggregating by overlap will use the degree indicated by the most recent overlap degree node in the provenance graph. I need confirmation that this functionality is intended; it seems to make sense that we don't need to record the default overlap degree in the provenance graph since it's always the same, and further changes to the degree are correctly Trracked.
