### PR TITLE
Update selected size bar color to match bookmark color

### DIFF
--- a/packages/upset/src/atoms/config/currentIntersectionAtom.ts
+++ b/packages/upset/src/atoms/config/currentIntersectionAtom.ts
@@ -27,6 +27,10 @@ export const bookmarkedIntersectionSelector = selector<Bookmark[]>({
   },
 });
 
+/**
+ * Represents the color palette for the bookmarked intersections.
+ * Maps intersection IDs to colors, both as strings.
+ */
 export const bookmarkedColorPalette = selector<{
   [intersection: string]: string;
 }>({
@@ -44,6 +48,10 @@ export const bookmarkedColorPalette = selector<{
   },
 });
 
+/**
+ * The next color to be used for a newly bookmarked intersection;
+ * comes from the queryColorPalette.
+ */
 export const nextColorSelector = selector<string>({
   key: 'color-selector',
   get: ({ get }) => {

--- a/packages/upset/src/components/Columns/SizeBar.tsx
+++ b/packages/upset/src/components/Columns/SizeBar.tsx
@@ -2,7 +2,7 @@ import { Row } from '@visdesignlab/upset2-core';
 import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { bookmarkedColorPalette, bookmarkedIntersectionSelector, currentIntersectionSelector } from '../../atoms/config/currentIntersectionAtom';
+import { bookmarkedColorPalette, bookmarkedIntersectionSelector, currentIntersectionSelector, nextColorSelector } from '../../atoms/config/currentIntersectionAtom';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 import { maxSize } from '../../atoms/maxSizeAtom';
 import { useScale } from '../../hooks/useScale';
@@ -24,6 +24,7 @@ export const SizeBar: FC<Props> = ({ row, size }) => {
   const currentIntersection = useRecoilValue(currentIntersectionSelector);
   const bookmarkedIntersections = useRecoilValue(bookmarkedIntersectionSelector);
   const bookmarkedColorPallete = useRecoilValue(bookmarkedColorPalette);
+  const nextColor = useRecoilValue(nextColorSelector);
 
   const scale = useScale(
     [0, sizeDomain],
@@ -58,7 +59,7 @@ export const SizeBar: FC<Props> = ({ row, size }) => {
 
     // We don't want to evaluate this to true if both currentIntersection and row are undefined, hence the 1st condition
     if (currentIntersection && currentIntersection?.id === row?.id) { // if currently selected, use the highlight colors
-      return highlightColors[index];
+      return nextColor;
     }
     return colors[index];
   }

--- a/packages/upset/src/components/Rows/MatrixRows.tsx
+++ b/packages/upset/src/components/Rows/MatrixRows.tsx
@@ -13,6 +13,11 @@ type Props = {
   rows: RenderRow[];
 };
 
+/**
+ * Renders a row based on its type.
+ * @param row - The row to be rendered.
+ * @returns The rendered row component.
+ */
 export function rowRenderer(row: Row) {
   if (isRowAggregate(row)) {
     return <AggregateRow aggregateRow={row} />;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #343 

### Give a longer description of what this PR addresses and why it's needed
Previously, when selecting a non-bookmarked intersection, the size bar would be a fixed light blue color while the chip in Element View would show the intersection using the next bookmark color. Now, the size bar of the selected intersection also uses the next bookmark color.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before: 
![343-before](https://github.com/visdesignlab/upset2/assets/58234814/e19f2c65-2ca8-41f7-8e12-52fef05a1a7a)
After: 
![343-after](https://github.com/visdesignlab/upset2/assets/58234814/0e4742e0-3c7f-4cde-8fa5-0f105b91a2c7)

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed (I can try and write a test to check the color of the element if you'd like)

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
