### PR TITLE
Sort By Set

### DIFF
--- a/e2e-tests/alttext.spec.ts
+++ b/e2e-tests/alttext.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';
@@ -57,16 +56,22 @@ test('Alt Text', async ({ page }) => {
   /// /////////////////
   /// Aggregates
   await page.getByRole('radio', { name: 'Degree' }).check();
-  const aggErrMsg = await page.getByText("Alt text generation is not yet supported for aggregated plots. To generate an alt text, set aggregation to 'None' in the left sidebar.");
+  const aggErrMsg = page.getByText("Alt text generation is not yet supported for aggregated plots. To generate an alt text, set aggregation to 'None' in the left sidebar.");
   await expect(aggErrMsg).toBeVisible();
   await page.getByRole('radio', { name: 'None' }).check();
 
   /// Attribute Sort
   await page.getByLabel('Age').locator('rect').dispatchEvent('click');
-  const attrSortErrMsg = await page.getByText('Alt text generation is not yet supported for attribute sorting. To generate an alt text, sort by Size, Degree, or Deviation.');
+  const attrSortErrMsg = page.getByText('Alt text generation is not yet supported for attribute sorting. To generate an alt text, sort by Size, Degree, or Deviation.');
   await expect(attrSortErrMsg).toBeVisible();
-  await page.getByText('Size', { exact: true }).dispatchEvent('click');
 
+  /// Set Sort
+  await page.locator('p').filter({ hasText: /^Male$/ }).click();
+  const setSortErrMsg = page.getByText('Alt text generation is not yet supported for set sorting. To generate an alt text, sort by Size, Degree, or Deviation.');
+  await expect(setSortErrMsg).toBeVisible();
+
+  // reset sorting to size
+  await page.getByText('Size', { exact: true }).dispatchEvent('click');
   /// /////////////////
   // Plot Information
   /// /////////////////

--- a/e2e-tests/attributeSelector.spec.ts
+++ b/e2e-tests/attributeSelector.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';

--- a/e2e-tests/datatable.spec.ts
+++ b/e2e-tests/datatable.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';

--- a/e2e-tests/elementView.spec.ts
+++ b/e2e-tests/elementView.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';

--- a/e2e-tests/plot.spec.ts
+++ b/e2e-tests/plot.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';
@@ -48,8 +47,8 @@ async function toggleAdvancedScale(page) {
  * @param setName name of set
  */
 async function removeSetByName(page, setName: string) {
-  await page.locator('p').filter({ hasText: new RegExp('^' + setName + '$') }).click({ button: 'right' });
-  await page.getByRole('menuitem', { name: 'Remove Set: ' + setName }).click();
+  await page.locator('p').filter({ hasText: new RegExp(`^${setName}$`) }).click({ button: 'right' });
+  await page.getByRole('menuitem', { name: `Remove Set: ${setName}` }).click();
 }
 
 /**
@@ -59,9 +58,9 @@ async function removeSetByName(page, setName: string) {
  */
 async function addSetByName(page, setName: string) {
   await page.getByText(setName, { exact: true }).click({
-    button: 'right'
+    button: 'right',
   });
-  await page.getByRole('menuitem', { name: 'Add Set: ' + setName }).click();
+  await page.getByRole('menuitem', { name: `Add Set: ${setName}` }).click();
 }
 
 /**
@@ -71,7 +70,7 @@ async function addSetByName(page, setName: string) {
  */
 async function assertSizeScaleMax(page, max: number) {
   await expect(page.locator('g.details-scale > g > g:last-child > text').nth(1))
-    .toHaveText(new RegExp('^' + max + '$'));
+    .toHaveText(new RegExp(`^${max}$`));
 }
 
 /**
@@ -88,21 +87,21 @@ test('Size header', async ({ page }) => {
   // Ensure that the scale decreases when necessary upon set removal
   await removeSetByName(page, 'Male');
   await assertSizeScaleMax(page, 8);
-  
+
   // Ensure that the scale updates upon set addition
   await addSetByName(page, 'Male');
   await assertSizeScaleMax(page, 5);
 
   // Ensure that dragging the advanced slider works
   await toggleAdvancedScale(page);
-  await page.locator('g').filter({ hasText: /^0055101015152020Size001122334455$/ }).locator('rect').nth(1).
-    dragTo(page.getByText('15', { exact: true }).nth(1), {force: true});
+  await page.locator('g').filter({ hasText: /^0055101015152020Size001122334455$/ }).locator('rect').nth(1)
+    .dragTo(page.getByText('15', { exact: true }).nth(1), { force: true });
   await assertSizeScaleMax(page, 15);
 
   // Ensure that adding sets doesn't affect the advanced scale
   await addSetByName(page, 'Blue Hair');
   await assertSizeScaleMax(page, 15);
-  
+
   // Ensure that scale recalculates correctly when advanced is turned off
   await toggleAdvancedScale(page);
   await assertSizeScaleMax(page, 3);

--- a/e2e-tests/provenance.spec.ts
+++ b/e2e-tests/provenance.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/prefer-screen-queries */
 import { test, expect } from '@playwright/test';
 import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
 import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';

--- a/e2e-tests/sort.spec.ts
+++ b/e2e-tests/sort.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect, Page } from '@playwright/test';
+import mockData from '../playwright/mock-data/simpsons/simpsons_data.json';
+import mockAnnotations from '../playwright/mock-data/simpsons/simpsons_annotations.json';
+import mockAltText from '../playwright/mock-data/simpsons/simpsons_alttxt.json';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('*/**/api/**', async (route) => {
+    const url = route.request().url();
+    let json;
+
+    if (url) {
+      if (url.includes('workspaces/Upset%20Examples/tables/simpsons/rows/?limit=9007199254740991')) {
+        json = mockData;
+        await route.fulfill({ json });
+      } else if (url.includes('workspaces/Upset%20Examples/tables/simpsons/annotations/')) {
+        json = mockAnnotations;
+        await route.fulfill({ json });
+      } else if (url.includes('alttxt')) {
+        json = mockAltText;
+        await route.fulfill({ json });
+      } else if (url.includes('workspaces/Upset%20Examples/sessions/table/193/state/')) {
+        await route.fulfill({ status: 200 });
+      } else {
+        await route.continue();
+      }
+    } else {
+      await route.abort();
+    }
+  });
+});
+
+const SIZE_ORDER = {
+  Ascending: [
+    'Subset_School',
+    'Subset_School~&amp;~Evil~&amp;~Male',
+    'Subset_School~&amp;~Blue_Hair~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Evil~&amp;~Male',
+    'Subset_Evil~&amp;~Male',
+  ],
+  Descending: [
+    'Subset_School~&amp;~Male',
+    'Subset_Unincluded',
+    'Subset_Male',
+    'Subset_Duff_Fan~&amp;~Male~&amp;~Power Plant',
+    'Subset_Evil~&amp;~Male',
+  ],
+};
+
+const DEGREE_ORDER = {
+  Ascending: [
+    'Subset_Unincluded',
+    'Subset_Blue_Hair',
+    'Subset_Male',
+    'Subset_School',
+    'Subset_Duff_Fan~&amp;~Male',
+  ],
+  Descending: [
+    'Subset_Duff_Fan~&amp;~Evil~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Male~&amp;~Power Plant',
+    'Subset_Evil~&amp;~Male~&amp;~Power_Plant',
+    'Subset_School~&amp;~Blue_Hair~&amp;~Male',
+    'Subset_School~&amp;~Evil~&amp;~Male',
+  ],
+};
+
+const DEVIATION_ORDER = {
+  Ascending: [
+    'Subset_Male',
+    'Subset_Evil~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Male',
+    'Subset_School',
+    'Subset_School~&amp;~Evil~&amp;~Male',
+  ],
+  Descending: [
+    'Subset_Duff_Fan~&amp;~Male~&amp;~Power Plant',
+    'Subset_Blue_Hair',
+    'Subset_Evil~&amp;~Male~&amp;~Power_Plant',
+    'Subset_School~&amp;~Male',
+    'Subset_Unincluded',
+  ],
+};
+
+// Note: the keys in this object represent the VISIBLE SET sort order
+const SET_MALE_ORDER = {
+  Alphabetical: [
+    'Subset_Male',
+    'Subset_Duff_Fan~&amp;~Male',
+    'Subset_Evil~&amp;~Male',
+    'Subset_School~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Evil~&amp;~Male',
+  ],
+  Ascending: [
+    'Subset_Male',
+    'Subset_School~&amp;~Male',
+    'Subset_Evil~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Male',
+    'Subset_School~&amp;~Blue_Hair~&amp;~Male',
+  ],
+  Descending: [
+    'Subset_Male',
+    'Subset_School~&amp;~Male',
+    'Subset_Evil~&amp;~Male',
+    'Subset_Duff_Fan~&amp;~Male',
+    'Subset_School~&amp;~Evil~&amp;~Male',
+  ],
+};
+
+/**
+ * Compares the sorted elements on a page with the given order.
+ *
+ * @param {Page} page - The playwright page object.
+ * @param {string[]} order - The expected order of elements.
+ * @returns {Promise<void>} - A promise that resolves when the comparison is complete.
+ */
+async function compareSortedElements(page: Page, order: string[]) {
+  const gElements = await page.locator('#matrixRows > g').all();
+
+  const res = (await Promise.all(gElements.map((gElement) => gElement.innerHTML()))).slice(0, 5);
+
+  for (let i = 0; i < order.length; i++) {
+    expect(res[i]).toContain(order[i]);
+  }
+}
+
+test('Sort by Size', async ({ page }) => {
+  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+
+  /// Ascending
+  await page.getByText('Size', { exact: true }).click();
+  await compareSortedElements(page, SIZE_ORDER.Ascending);
+
+  /// Descending
+  await page.getByText('Size', { exact: true }).click();
+  await compareSortedElements(page, SIZE_ORDER.Descending);
+});
+
+test('Sort by Degree', async ({ page }) => {
+  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+
+  /// Ascending
+  await page.getByText('#').click();
+  await compareSortedElements(page, DEGREE_ORDER.Ascending);
+
+  /// Descending
+  await page.getByText('#').click();
+  await compareSortedElements(page, DEGREE_ORDER.Descending);
+});
+
+test('Sort by Deviation', async ({ page }) => {
+  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+
+  /// Ascending
+  await page.getByLabel('Deviation', { exact: true }).locator('rect').dispatchEvent('click');
+  await compareSortedElements(page, DEVIATION_ORDER.Ascending);
+
+  /// Descending
+  await page.getByLabel('Deviation', { exact: true }).locator('rect').dispatchEvent('click');
+  await compareSortedElements(page, DEVIATION_ORDER.Descending);
+});
+
+test('Sort by Set Male', async ({ page }) => {
+  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+
+  /// Only one option for sortOrder for sets
+  await page.locator('p').filter({ hasText: /^Male$/ }).click();
+  await compareSortedElements(page, SET_MALE_ORDER.Alphabetical);
+
+  // Sort visible sets by size, ascending
+  // male is largest, so this should put it at the end.
+  // This will alter the order of the sets
+  await page.locator('p').filter({ hasText: /^Male$/ }).dispatchEvent('contextmenu');
+  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Ascending' }).click();
+
+  await compareSortedElements(page, SET_MALE_ORDER.Ascending);
+
+  await page.locator('p').filter({ hasText: /^Male$/ }).dispatchEvent('contextmenu');
+  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Descending' }).click();
+
+  await compareSortedElements(page, SET_MALE_ORDER.Descending);
+});

--- a/e2e-tests/sort.spec.ts
+++ b/e2e-tests/sort.spec.ts
@@ -126,11 +126,11 @@ test('Sort by Size', async ({ page }) => {
   await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
 
   /// Ascending
-  await page.getByText('Size', { exact: true }).click();
+  await page.getByText('Size', { exact: true }).dispatchEvent('click');
   await compareSortedElements(page, SIZE_ORDER.Ascending);
 
   /// Descending
-  await page.getByText('Size', { exact: true }).click();
+  await page.getByText('Size', { exact: true }).dispatchEvent('click');
   await compareSortedElements(page, SIZE_ORDER.Descending);
 });
 
@@ -162,19 +162,19 @@ test('Sort by Set Male', async ({ page }) => {
   await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
 
   /// Only one option for sortOrder for sets
-  await page.locator('p').filter({ hasText: /^Male$/ }).click();
+  await page.locator('p').filter({ hasText: /^Male$/ }).dispatchEvent('click');
   await compareSortedElements(page, SET_MALE_ORDER.Alphabetical);
 
   // Sort visible sets by size, ascending
   // male is largest, so this should put it at the end.
   // This will alter the order of the sets
   await page.locator('p').filter({ hasText: /^Male$/ }).dispatchEvent('contextmenu');
-  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Ascending' }).click();
+  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Ascending' }).dispatchEvent('click');
 
   await compareSortedElements(page, SET_MALE_ORDER.Ascending);
 
   await page.locator('p').filter({ hasText: /^Male$/ }).dispatchEvent('contextmenu');
-  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Descending' }).click();
+  await page.getByRole('menuitem', { name: 'Sort Sets by Size - Descending' }).dispatchEvent('click');
 
   await compareSortedElements(page, SET_MALE_ORDER.Descending);
 });

--- a/e2e-tests/sort.spec.ts
+++ b/e2e-tests/sort.spec.ts
@@ -138,11 +138,11 @@ test('Sort by Degree', async ({ page }) => {
   await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
 
   /// Ascending
-  await page.getByText('#').click();
+  await page.getByText('#').dispatchEvent('click');
   await compareSortedElements(page, DEGREE_ORDER.Ascending);
 
   /// Descending
-  await page.getByText('#').click();
+  await page.getByText('#').dispatchEvent('click');
   await compareSortedElements(page, DEGREE_ORDER.Descending);
 });
 

--- a/packages/app/src/components/AttributeDropdown.tsx
+++ b/packages/app/src/components/AttributeDropdown.tsx
@@ -69,7 +69,7 @@ export const AttributeDropdown = (props: {anchorEl: HTMLElement, close: () => vo
 
   const attributeItemCount: { [attr: string]: number | string } = {};
 
-  const attributes = data ? [...data.attributeColumns, ...DefaultConfig.visibleAttributes]: [...DefaultConfig.visibleAttributes];
+  const attributes = data ? [...DefaultConfig.visibleAttributes, ...data.attributeColumns]: [...DefaultConfig.visibleAttributes];
     
 
   if (data) {

--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -67,7 +67,7 @@ export const Body = ({ yOffset, data, config }: Props) => {
     }
 
     if (!['Size', 'Degree', 'Deviation'].includes(config.sortBy)) {
-      throw new Error("Alt text generation is not yet supported for attribute sorting. To generate an alt text, sort by Size, Degree, or Deviation.");
+      throw new Error(`Alt text generation is not yet supported for ${config.sortBy.includes("Set_") ? 'set' : 'attribute'} sorting. To generate an alt text, sort by Size, Degree, or Deviation.`);
     }
 
     let response;

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -117,7 +117,6 @@ function sortByDeviation(rows: Intersections, sortByOrder?: SortByOrder) {
  * @param sortBy - The set to sort by.
  * @param vSetSortBy - The sort order for visible sets.
  * @param visibleSets - The visible sets.
- * @param sortByOrder - The sort order for the specified set. (optional)
  * @returns The sorted rows.
  */
 function sortBySet(rows: Intersections, sortBy: string, vSetSortBy: SortVisibleBy, visibleSets: Sets) {
@@ -146,7 +145,7 @@ function sortBySet(rows: Intersections, sortBy: string, vSetSortBy: SortVisibleB
   const sortedNonSetMembers = sortByDegree(nonSetMembers, vSetSortBy, visibleSets, 'Ascending');
 
   // combine the two sorted row lists
-  const sortedOrder = sortedSetMembers.order.concat(sortedNonSetMembers.order);
+  const sortedOrder = [...sortedSetMembers.order, ...sortedNonSetMembers.order];
   const sortedValues = { ...sortedSetMembers.values, ...sortedNonSetMembers.values };
 
   return { values: sortedValues, order: sortedOrder };

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -200,7 +200,7 @@ function sortIntersections<T extends Intersections>(
   sortByOrder?: SortByOrder,
 ) {
   if (sortBy.includes('Set_')) {
-    return sortBySet(intersections, sortBy, vSetSortBy, visibleSets, sortByOrder);
+    return sortBySet(intersections, sortBy, vSetSortBy, visibleSets);
   }
 
   switch (sortBy) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,7 +156,6 @@ export const aggregateByList = [
 ] as const;
 export type AggregateBy = typeof aggregateByList[number];
 
-export type SortBy = string;
 export type SortByOrder = 'Ascending' | 'Descending';
 
 export const sortVisibleByList = ['Alphabetical', 'Ascending', 'Descending'] as const;
@@ -228,7 +227,7 @@ export type UpsetConfig = {
   secondAggregateBy: AggregateBy;
   secondOverlapDegree: number;
   sortVisibleBy: SortVisibleBy;
-  sortBy: SortBy;
+  sortBy: string;
   sortByOrder: SortByOrder;
   filters: {
     maxVisible: number;

--- a/packages/upset/src/components/Rows/AggregateRow.tsx
+++ b/packages/upset/src/components/Rows/AggregateRow.tsx
@@ -71,6 +71,10 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
     width -= dimensions.body.aggregateOffset;
   }
 
+  /**
+   * Truncates the element name if it is longer than 14 characters and the aggregateBy value is 'Overlaps'.
+   * Otherwise, description is the element name.
+   */
   const desc =
     aggregateRow.elementName.length < 14 ||
     aggregateRow.aggregateBy !== 'Overlaps'
@@ -79,8 +83,9 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
 
   return (
     <g
-      onClick={() => aggregateRow && 
-        (currentIntersection?.id === aggregateRow.id ? 
+      id={aggregateRow.id}
+      onClick={() => aggregateRow &&
+        (currentIntersection?.id === aggregateRow.id ?
           actions.setSelected(null) : actions.setSelected(aggregateRow))}
       css={mousePointer}
     >

--- a/packages/upset/src/components/Rows/MatrixRows.tsx
+++ b/packages/upset/src/components/Rows/MatrixRows.tsx
@@ -87,7 +87,7 @@ export const MatrixRows: FC<Props> = ({ rows }) => {
   );
 
   return (
-    <g onClick={(e) => e.stopPropagation()}>
+    <g id="matrixRows" onClick={(e) => e.stopPropagation()}>
       {rowTransitions(({ transform }, item) => (
         shouldRender(item.row) &&
           <a.g key={item.id} transform={transform}>{rowRenderer(item.row)}</a.g>

--- a/packages/upset/src/components/Rows/SubsetRow.tsx
+++ b/packages/upset/src/components/Rows/SubsetRow.tsx
@@ -49,6 +49,7 @@ export const SubsetRow: FC<Props> = ({ subset }) => {
 
   return (
     <g
+      id={subset.id}
       onClick={
         () => {
           if (currentIntersection?.id === subset.id) { // if the row is already selected, deselect it

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -326,7 +326,7 @@ export function getActions(provenance: UpsetProvenance) {
     secondAggregateBy: (aggBy: AggregateBy) => provenance.apply(`Second aggregate by ${aggBy}`, secondAggAction(aggBy)),
     secondOverlapBy: (overlap: number) => provenance.apply(`Second overlap by ${overlap}`, secondOverlapAction(overlap)),
     sortVisibleBy: (sort: SortVisibleBy) => provenance.apply(`Sort Visible Sets by ${sort}`, sortVisibleSetsAction(sort)),
-    sortBy: (sort: SortBy, sortByOrder?: SortByOrder) => provenance.apply(`Sort by ${sort.replace('Set_', 'Set: ')}${sortByOrder ? `, ${sortByOrder}` : ''}`, sortByAction({ sort, sortByOrder })),
+    sortBy: (sort: string, sortByOrder?: SortByOrder) => provenance.apply(`Sort by ${sort.replace('Set_', 'Set: ')}${sortByOrder ? `, ${sortByOrder}` : ''}`, sortByAction({ sort, sortByOrder })),
     setMaxVisible: (val: number) => provenance.apply(`Hide intersections above ${val}`, maxVisibleAction(val)),
     setMinVisible: (val: number) => provenance.apply(`Hide intersections below ${val}`, minVisibleAction(val)),
     setHideEmpty: (val: boolean) => provenance.apply(val ? 'Hide empty intersections' : 'Show empty intersections', hideEmptyAction(val)),

--- a/packages/upset/src/provenance/index.ts
+++ b/packages/upset/src/provenance/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {
-  AggregateBy, Plot, PlotInformation, SortBy, SortByOrder, SortVisibleBy, UpsetConfig, DefaultConfig, Row
+  AggregateBy, Plot, PlotInformation, SortBy, SortByOrder, SortVisibleBy, UpsetConfig, DefaultConfig, Row,
 } from '@visdesignlab/upset2-core';
 
 import { Registry, initializeTrrack } from '@trrack/core';
@@ -60,7 +60,8 @@ const sortByAction = registry.register(
   'sort-by',
   (state, { sort, sortByOrder }) => {
     state.sortBy = sort;
-    state.sortByOrder = sortByOrder;
+    // should only be 'None' if sortBy is a Set
+    state.sortByOrder = sortByOrder || 'None';
     return state;
   },
 );
@@ -325,7 +326,7 @@ export function getActions(provenance: UpsetProvenance) {
     secondAggregateBy: (aggBy: AggregateBy) => provenance.apply(`Second aggregate by ${aggBy}`, secondAggAction(aggBy)),
     secondOverlapBy: (overlap: number) => provenance.apply(`Second overlap by ${overlap}`, secondOverlapAction(overlap)),
     sortVisibleBy: (sort: SortVisibleBy) => provenance.apply(`Sort Visible Sets by ${sort}`, sortVisibleSetsAction(sort)),
-    sortBy: (sort: SortBy, sortByOrder: SortByOrder) => provenance.apply(`Sort by ${sort}, ${sortByOrder}`, sortByAction({ sort, sortByOrder })),
+    sortBy: (sort: SortBy, sortByOrder?: SortByOrder) => provenance.apply(`Sort by ${sort.replace('Set_', 'Set: ')}${sortByOrder ? `, ${sortByOrder}` : ''}`, sortByAction({ sort, sortByOrder })),
     setMaxVisible: (val: number) => provenance.apply(`Hide intersections above ${val}`, maxVisibleAction(val)),
     setMinVisible: (val: number) => provenance.apply(`Hide intersections below ${val}`, minVisibleAction(val)),
     setHideEmpty: (val: boolean) => provenance.apply(val ? 'Hide empty intersections' : 'Show empty intersections', hideEmptyAction(val)),
@@ -347,10 +348,10 @@ export function getActions(provenance: UpsetProvenance) {
     expandAll: () => provenance.apply('Expanded all rows', expandAllAction([])),
     setPlotInformation: (plotInformation: PlotInformation) => provenance.apply('Update plot information', setPlotInformationAction(plotInformation)),
     setSelected: (intersection: Row) => provenance.apply(
-      intersection ? 
-      `Select intersection "${intersection.elementName.replaceAll('~&~', ' & ')}"` :
-      'Deselect intersection', 
-      setSelectedAction(intersection)
+      intersection ?
+        `Select intersection "${intersection.elementName.replaceAll('~&~', ' & ')}"` :
+        'Deselect intersection',
+      setSelectedAction(intersection),
     ),
   };
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #146 

### Give a longer description of what this PR addresses and why it's needed
This PR adds the ability to sort the UpSet plot by a set, aka, bringing a set to the top. See #113 for example context menu for sets.

The implemented behavior is based on the original Upset behavior here: [http://vcg.github.io/upset/](http://vcg.github.io/upset/)

This PR also removes any reference to the SortBy type, as this is only a string alias.

### Provide pictures/videos of the behavior before and after these changes (optional)
BEFORE: 
![upset-sortbyset-before](https://github.com/visdesignlab/upset2/assets/35744963/496a914d-0fc1-4f8c-b3d0-d308678b3ad2)

AFTER:
![upset-sortbyset-after](https://github.com/visdesignlab/upset2/assets/35744963/e6df23e9-eccc-403f-b347-71b5315c840f)


### Have you added or updated relevant tests?
- [X] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- none
