### PR TITLE
Add permissions logic for user updates to accessibility sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ const main = () => {
 - `elementSidebar` (optional): [Sidebar options](#sidebar-options) for the element visualization sidebar. This sidebar is used for element queries, element selection datatable, and supplimental plot generation.
 - `altTextSidebar` (optional): [Sidebar options](#sidebar-options) for the text description sidebar. This sidebar is used to display the generated text descriptions for an Upset 2.0 plot, given that the `generateAltText` function is provided.
 - `generateAltText` (optional)(`() => Promise<AltText>`): Async function which should return a generated AltText object. See [Alt Text Generation](#alt-text-generation) for more information about Alt Text generation.
+- `userEditPerms` (optional)(boolean): Whether or not the user has permissions to edit the Text Description plot information and descriptions. Defaults to `true`.
 
 ##### Configuration (Grammar) options
 

--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -5,7 +5,7 @@ import { encodedDataAtom } from '../atoms/dataAtom';
 import { doesHaveSavedQueryParam, queryParamAtom, saveQueryParam } from '../atoms/queryParamAtom';
 import { ErrorModal } from './ErrorModal';
 import { ProvenanceContext } from './Root';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { provenanceVisAtom } from '../atoms/provenanceVisAtom';
 import React from 'react';
 import { elementSidebarAtom } from '../atoms/elementSidebarAtom';
@@ -48,6 +48,18 @@ export const Body = ({ data, config }: Props) => {
       api.updateSession(workspace || '', parseInt(sessionId || ''), 'table', provObject.provenance.exportObject());
     })
   }, [provObject.provenance, sessionId, workspace]);
+
+  const [userEditPerms, setUserEditPerms] = useState(false);
+
+  useEffect(() => {
+    api.getCurrentUserWorkspacePermissions(workspace || '').then((r) => {
+      // https://api.multinet.app/swagger/?format=openapi#/definitions/PermissionsReturn for possible permissions returns
+      if (r.permission_label === 'owner' || r.permission_label === 'maintainer') {
+        setUserEditPerms(true);
+      }
+    });
+  }, [workspace]);
+
 
   /**
    * Generates alt text for a plot based on the current state and configuration.
@@ -105,8 +117,9 @@ export const Body = ({ data, config }: Props) => {
           </Backdrop>
           <Upset
             data={data}
-            extProvenance={provObject}
             config={config}
+            userEditPerms={userEditPerms}
+            extProvenance={provObject}
             provVis={provVis}
             elementSidebar={elementSidebar}
             altTextSidebar={altTextSidebar}

--- a/packages/upset/src/atoms/config/multinetAtoms.ts
+++ b/packages/upset/src/atoms/config/multinetAtoms.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const userEditPermsAtom = atom<boolean>({
+  key: 'user-edit-perms',
+  default: false,
+});

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -14,14 +14,15 @@ import {
   useMemo,
 } from 'react';
 import { useRecoilValue } from 'recoil';
+import { AltText } from '@visdesignlab/upset2-core/';
 import { ProvenanceContext } from './Root';
 import { upsetConfigAtom } from '../atoms/config/upsetConfigAtoms';
-import { AltText } from '@visdesignlab/upset2-core/';
 import ReactMarkdownWrapper from './custom/ReactMarkdownWrapper';
 import '../index.css';
 import { HelpCircle } from './custom/HelpCircle';
 import { PlotInformation } from './custom/PlotInformation';
 import { UpsetActions } from '../provenance';
+import { userEditPermsAtom } from '../atoms/config/multinetAtoms';
 
 /**
  * Props for the AltTextSidebar component.
@@ -62,12 +63,13 @@ const initialDrawerWidth = 450;
 */
 export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
   const { actions }: {actions: UpsetActions} = useContext(ProvenanceContext);
-  
+
   const currState = useRecoilValue(upsetConfigAtom);
+  const userEditPerms = useRecoilValue(userEditPermsAtom);
 
   const [altText, setAltText] = useState<AltText | null>(null);
   const [textGenErr, setTextGenErr] = useState<string | false>(false);
-  
+
   // States for editing the alt text
   const [textEditing, setTextEditing] = useState(false);
   const [userLongText, setUserLongText] = useState(currState.userAltText?.longDescription);
@@ -79,11 +81,9 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
    */
   function saveButtonClick() {
     setTextEditing(false);
-    if (!currState.useUserAlt)
-      actions.setUseUserAltText(true);
-    if (currState.userAltText?.shortDescription !== userShortText 
-        || currState.userAltText?.longDescription !== userLongText)  
-      actions.setUserAltText({shortDescription: userShortText ?? "", longDescription: userLongText ?? ""});
+    if (!currState.useUserAlt) actions.setUseUserAltText(true);
+    if (currState.userAltText?.shortDescription !== userShortText
+        || currState.userAltText?.longDescription !== userLongText) { actions.setUserAltText({ shortDescription: userShortText ?? '', longDescription: userLongText ?? '' }); }
   }
 
   // values added as a dependency here indicate values which are usable to the alt-text generator API call
@@ -98,28 +98,29 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
         setTextGenErr(msg);
       }
     }
-    
+
     generate();
   }, [currState]);
 
   // Current alt text to display to the user
   const displayAltText: string | undefined = useMemo(() => {
-    if (textEditing)
-      if (useLong) return userLongText ?? altText?.longDescription
-      else return userShortText ?? altText?.shortDescription
-    else if (useLong) return currState.useUserAlt ? userLongText : altText?.longDescription 
-    else return currState.useUserAlt ? userShortText : altText?.shortDescription;
+    if (textEditing) {
+      if (useLong) return userLongText ?? altText?.longDescription;
+      return userShortText ?? altText?.shortDescription;
+    }
+    if (useLong) return currState.useUserAlt ? userLongText : altText?.longDescription;
+    return currState.useUserAlt ? userShortText : altText?.shortDescription;
   }, [useLong, userLongText, userShortText, altText?.shortDescription, altText?.longDescription, currState.useUserAlt]);
-  
+
   const divider = <Divider
     css={css`
       width: 100%;
       margin: auto;
       margin-bottom: 1em;
     `}
-    aria-hidden={true}
-  />
-  
+    aria-hidden
+  />;
+
   return (
     <Drawer
       aria-hidden={!open}
@@ -152,118 +153,132 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
         </Typography>
         {divider}
         <Box marginTop={2} css={css`overflow-y: auto;`}>
-          {!textGenErr ? (<>
-            <FormControlLabel
-              style={{marginLeft: "5px"}} // Align with below text; has 2px border & 3px padding
-              sx={{ '& span': { fontSize: '0.8rem' } }} // Fontsize can't be set in style prop for some reason
-              label="View User Description(s)"
-              control={
-                <Switch
-                  size="small"
-                  style={{marginRight: "10px"}}
-                  checked={currState.useUserAlt || textEditing}
-                  tabIndex={9}
-                  onChange={(ev) => {
-                    if (currState.useUserAlt !== ev.target.checked)
-                      actions.setUseUserAltText(ev.target.checked);
-                    if (!ev.target.checked) {
-                      setTextEditing(false);
-                    }
-                  }}
-                />
+          {!textGenErr ? (
+            <>
+              <FormControlLabel
+                disabled={!userEditPerms}
+                style={{ marginLeft: '5px' }} // Align with below text; has 2px border & 3px padding
+                sx={{ '& span': { fontSize: '0.8rem' } }} // Fontsize can't be set in style prop for some reason
+                label="View User Description(s)"
+                control={
+                  <Switch
+                    size="small"
+                    style={{ marginRight: '10px' }}
+                    checked={currState.useUserAlt || textEditing}
+                    tabIndex={9}
+                    onChange={(ev) => {
+                      if (currState.useUserAlt !== ev.target.checked) actions.setUseUserAltText(ev.target.checked);
+                      if (!ev.target.checked) {
+                        setTextEditing(false);
+                      }
+                    }}
+                  />
               }
-              labelPlacement="start"
-            />
-            <HelpCircle 
-              text={"When enabled, allows you to enter a custom alternative text description."}
-              margin={{left: 12, top: 0, right: 0, bottom: 0}}
-            />
-            <br />
-            <FormControlLabel
-              style={{marginLeft: "5px"}} // Align with below text; has 2px border & 3px padding
-              sx={{ '& span': { fontSize: '0.8rem' } }} // Fontsize can't be set in style prop for some reason
-              label="Display Long Description"
-              control={
-                <Switch
-                  size="small"
-                  checked={useLong}
-                  tabIndex={8}
-                  onChange={(ev) => {
-                    setUseLong(ev.target.checked);
-                  }}
-                />
-              }
-              labelPlacement="start"
-            />
-            <HelpCircle 
-              text={"When enabled, displays the long text description for this plot instead of the short version."}
-              margin={{left: 12, top: 0, right: 0, bottom: 0}} 
-            />
-          </>) : (
-            <Typography variant="body1" color="error">{textGenErr}</Typography>
-          )}
-          {textEditing ? (<>
-            <Button 
-              color="primary" 
-              style={{float: 'right'}} 
-              onClick={saveButtonClick}
-              tabIndex={7}
-            >Save</Button>
-            <Button
-              color='warning'
-              style={{float: "right"}}
-              onClick={() => {
-                setUserLongText(altText?.longDescription);
-                setUserShortText(altText?.shortDescription);
-              }}
-              tabIndex={6}
-            >Reset Descriptions</Button>
-            <br />
-            <TextField multiline fullWidth
-              onChange={(e) => useLong ? setUserLongText(e.target.value) : setUserShortText(e.target.value)}
-              value={(displayAltText)}
-              tabIndex={5}
-            />
-            <br />
-          </>) : (
-            <div 
-              style={{
-                overflowY: 'auto',
-                cursor: 'pointer',
-                padding: '3px',
-                borderRadius: '4px',
-                width: 'calc(100% - 10px)', // We have 10px of padding + border
-                paddingBottom: '90px', // Necessary to keep it above the footer
-              }}
-              onClick={() => {
-                setTextEditing(true);
-                if (!currState.userAltText?.shortDescription)
-                  setUserShortText(altText?.shortDescription);
-                if (!currState.userAltText?.longDescription)
-                  setUserLongText(altText?.longDescription);
-              }}
-              tabIndex={3}  
-            >
-              <ReactMarkdownWrapper 
-                text={
-                  displayAltText ?? (currState.useUserAlt 
-                    ? "No user-generated description available." 
-                    : "No description available.")
-                }
+                labelPlacement="start"
               />
-              <Button
-                style={{
-                  width: '100%',
-                  textAlign: 'center',
+              <HelpCircle
+                text="When enabled, allows you to enter a custom alternative text description."
+                margin={{
+                  left: 12, top: 0, right: 0, bottom: 0,
                 }}
-                onClick={() => setTextEditing(true)}
-                tabIndex={4}
-              >Edit Text Description</Button>
-            </div>
+              />
+              <br />
+              <FormControlLabel
+                style={{ marginLeft: '5px' }} // Align with below text; has 2px border & 3px padding
+                sx={{ '& span': { fontSize: '0.8rem' } }} // Fontsize can't be set in style prop for some reason
+                label="Display Long Description"
+                control={
+                  <Switch
+                    size="small"
+                    checked={useLong}
+                    tabIndex={8}
+                    onChange={(ev) => {
+                      setUseLong(ev.target.checked);
+                    }}
+                  />
+              }
+                labelPlacement="start"
+              />
+              <HelpCircle
+                text="When enabled, displays the long text description for this plot instead of the short version."
+                margin={{
+                  left: 12, top: 0, right: 0, bottom: 0,
+                }}
+              />
+            </>) : (
+              <Typography variant="body1" color="error">{textGenErr}</Typography>
+          )}
+          {textEditing ? (
+            <>
+              <Button
+                color="primary"
+                style={{ float: 'right' }}
+                onClick={saveButtonClick}
+                tabIndex={7}
+              >
+                Save
+              </Button>
+              <Button
+                color="warning"
+                style={{ float: 'right' }}
+                onClick={() => {
+                  setUserLongText(altText?.longDescription);
+                  setUserShortText(altText?.shortDescription);
+                }}
+                tabIndex={6}
+              >
+                Reset Descriptions
+              </Button>
+              <br />
+              <TextField
+                multiline
+                fullWidth
+                onChange={(e) => (useLong ? setUserLongText(e.target.value) : setUserShortText(e.target.value))}
+                value={(displayAltText)}
+                tabIndex={5}
+              />
+              <br />
+            </>) : (
+              <div
+                style={{
+                  overflowY: 'auto',
+                  cursor: `${userEditPerms && 'pointer'}`,
+                  padding: '3px',
+                  borderRadius: '4px',
+                  width: 'calc(100% - 10px)', // We have 10px of padding + border
+                  paddingBottom: '90px', // Necessary to keep it above the footer
+                }}
+                onClick={() => {
+                  if (userEditPerms) {
+                    setTextEditing(true);
+                    if (!currState.userAltText?.shortDescription) setUserShortText(altText?.shortDescription);
+                    if (!currState.userAltText?.longDescription) setUserLongText(altText?.longDescription);
+                  }
+                }}
+                tabIndex={3}
+              >
+                <ReactMarkdownWrapper
+                  text={
+                  displayAltText ?? (currState.useUserAlt
+                    ? 'No user-generated description available.'
+                    : 'No description available.')
+                }
+                />
+                <Button
+                  disabled={!userEditPerms}
+                  style={{
+                    width: '100%',
+                    textAlign: 'center',
+                  }}
+                  onClick={() => setTextEditing(true)}
+                  tabIndex={4}
+                >
+                  Edit Text Description
+                </Button>
+              </div>
           )}
         </Box>
       </div>
     </Drawer>
   );
 };
-      

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -26,6 +26,7 @@ import { ContextMenu } from './ContextMenu';
 import { ProvenanceVis } from './ProvenanceVis';
 import { AltTextSidebar } from './AltTextSidebar';
 import { AltText } from '../types';
+import { userEditPermsAtom } from '../atoms/config/multinetAtoms';
 
 export const ProvenanceContext = createContext<{
   provenance: UpsetProvenance;
@@ -36,9 +37,14 @@ const baseStyle = css`
   padding: 0.25em;
 `;
 
+/**
+ * Props for the root component.
+ * @see UpsetProps for information about these props
+ */
 type Props = {
   data: CoreUpsetData;
   config: UpsetConfig;
+  userEditPerms?: boolean;
   allowAttributeRemoval?: boolean;
   hideSettings?: boolean;
   extProvenance?: {
@@ -61,7 +67,7 @@ type Props = {
 };
 
 export const Root: FC<Props> = ({
-  data, config, allowAttributeRemoval, hideSettings, extProvenance, provVis, elementSidebar, altTextSidebar, generateAltText,
+  data, config, userEditPerms = true, allowAttributeRemoval, hideSettings, extProvenance, provVis, elementSidebar, altTextSidebar, generateAltText,
 }) => {
   // Get setter for recoil config atom
   const setState = useSetRecoilState(upsetConfigAtom);
@@ -73,11 +79,19 @@ export const Root: FC<Props> = ({
   const setData = useSetRecoilState(dataAtom);
   const setContextMenu = useSetRecoilState(contextMenuAtom);
   const setAllowAttributeRemoval = useSetRecoilState(allowAttributeRemovalAtom);
+  const setUserEditPerms = useSetRecoilState(userEditPermsAtom);
 
   useEffect(() => {
     setState(config);
     setData(data);
   }, []);
+
+  /**
+   * Update the user edit permissions when the prop changes (ie: user login).
+   */
+  useEffect(() => {
+    setUserEditPerms(userEditPerms);
+  }, [userEditPerms]);
 
   // Initialize Provenance and pass it setter to connect
   const { provenance, actions } = useMemo(() => {

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -16,6 +16,7 @@ const defaultVisibleSets = 6;
  * @component
  * @param {CoreUpsetData | UpsetItem[]} data - The data for the Upset component.
  * @param {Partial<UpsetConfig>} [config={}] - The configuration options for the Upset component. This can be partial.
+ * @param {boolean} [userEditPerms=true] - Indicates if the user is an admin or owner of the workspace. This is used to determine if the user can make edits to the plot information. Defaults to true.
  * @param {string[]} [visualizeAttributes] - List of attribute names (strings) which should be visualized. Defaults to the first 3 if no value is provided. If an empty list is provided, displays no attributes.
  * @param {boolean} [visualizeUpsetAttributes=false] - Whether or not to visualize UpSet generated attributes (`degree` and `deviation`). Defaults to `false`.
  * @param {boolean} [allowAttributeRemoval=false] - Whether or not to allow the user to remove attribute columns. This should be enabled only if there is an option within the parent application which allows for attributes to be added after removal. Default attribute removal behavior in UpSet 2.0 is done via context menu on attribute headers. Defaults to `false`.
@@ -30,12 +31,13 @@ const defaultVisibleSets = 6;
  */
 export const Upset: FC<UpsetProps> = ({
   data,
-  parentHasHeight = false,
   config = {},
+  userEditPerms = true,
   visualizeDatasetAttributes,
   visualizeUpsetAttributes = false,
   allowAttributeRemoval = false,
   hideSettings,
+  parentHasHeight = false,
   extProvenance,
   provVis,
   elementSidebar,
@@ -100,6 +102,7 @@ export const Upset: FC<UpsetProps> = ({
           <Root
             data={processData}
             config={combinedConfig}
+            userEditPerms={userEditPerms}
             allowAttributeRemoval={allowAttributeRemoval}
             hideSettings={hideSettings}
             extProvenance={extProvenance}

--- a/packages/upset/src/components/custom/PlotInformation.tsx
+++ b/packages/upset/src/components/custom/PlotInformation.tsx
@@ -6,10 +6,11 @@ import {
   Typography,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import { plotInformationSelector } from '../../atoms/config/plotInformationAtom';
 import { useRecoilValue } from 'recoil';
 import { useContext, useState } from 'react';
+import { plotInformationSelector } from '../../atoms/config/plotInformationAtom';
 import { ProvenanceContext } from '../Root';
+import { userEditPermsAtom } from '../../atoms/config/multinetAtoms';
 
 /**
  * Props for the PlotInformation component.
@@ -35,9 +36,9 @@ type Props = {
  * Uses up to 5 tab indices, starting from @param tabIndex
  * @param Props @see @type Props
  */
-export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
+export const PlotInformation = ({ onSave, divider, tabIndex }: Props) => {
   /**
-   * Width of the titles for all the fields in %. 
+   * Width of the titles for all the fields in %.
    * Field entry boxes will occupy the rest of the space
    */
   const fieldTitleWidth = 30;
@@ -49,12 +50,12 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
     margin: '0.25em 0',
     minHeight: '4em',
   };
-  
+
   const plotInfoTitle = {
     fontSize: '1em',
     fontWeight: 'inherit',
     color: 'GrayText',
-    width: fieldTitleWidth + '%',
+    width: `${fieldTitleWidth}%`,
   };
 
   const placeholderText = {
@@ -64,6 +65,7 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
   };
 
   const plotInformationState = useRecoilValue(plotInformationSelector);
+  const userEditPerms = useRecoilValue(userEditPermsAtom);
   const [plotInformation, setPlotInformation] = useState(plotInformationState);
   const { actions } = useContext(ProvenanceContext);
 
@@ -78,7 +80,7 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
     if (Object.values(plotInformation).filter((a) => a.length > 0).length === 0) {
       return `This UpSet plot shows ${placeholderText.description}. The sets are ${placeholderText.sets}. The items are ${placeholderText.items}`;
     }
-    
+
     let str: string = '';
     if (plotInformation.description !== '') {
       str += `This UpSet plot shows ${plotInformation.description}. `;
@@ -89,23 +91,22 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
     if (plotInformation.items !== '') {
       str += `The items are ${plotInformation.items}.`;
     }
-    
+
     return str;
   };
 
   /**
    * Commits changes to the plot information if the new state is different from the old state.
-   * If a commit occurs, records a trrack action. 
+   * If a commit occurs, records a trrack action.
    */
-  const commitEdits = () => { 
+  const commitEdits = () => {
     if ( // Need to manually check for changes since the state is an object
       plotInformation.caption !== plotInformationState.caption
       || plotInformation.title !== plotInformationState.title
       || plotInformation.description !== plotInformationState.description
       || plotInformation.sets !== plotInformationState.sets
       || plotInformation.items !== plotInformationState.items
-    )
-      actions.setPlotInformation(plotInformation);
+    ) actions.setPlotInformation(plotInformation);
     if (onSave) onSave();
     setEditing(false);
   };
@@ -114,72 +115,78 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
     !editing ? (
       <Box
         tabIndex={tabIndex}
-        onClick={() => setEditing(true)}
-        sx={{ 
-          cursor: 'pointer',
+        onClick={() => { if (userEditPerms) setEditing(true); }}
+        sx={{
+          cursor: `${userEditPerms && 'pointer'}`,
           border: '2px solid white', // Prevent resize on hover
           padding: '.2em',
           '&:hover': {
-            border: '2px inset #ddd', 
-          }
+            border: `${userEditPerms && '2px inset #ddd'}`,
+          },
         }}
       >
-        <div style={{height: '1.6em'}}>
+        <div style={{ height: '1.6em' }}>
           <Typography variant="h2" fontSize="1.2em" fontWeight="inherit" height="1.4em" padding="0">
-            {plotInformation.title ?? "[Title]"}
+            {plotInformation.title ?? '[Title]'}
           </Typography>
-          <Button 
-            aria-label='Edit Plot Information' 
-            style={{float: 'right', position: 'relative', bottom: '40px'}} 
+          <Button
+            disabled={!userEditPerms}
+            aria-label="Edit Plot Information"
+            style={{ float: 'right', position: 'relative', bottom: '40px' }}
             tabIndex={tabIndex + 1}
           >
-            <Icon style={{overflow: 'visible'}}>
+            <Icon style={{ overflow: 'visible' }}>
               <EditIcon />
             </Icon>
           </Button>
         </div>
         {divider}
-        <Typography>{plotInformation.caption ?? "[Caption]"}</Typography>
+        <Typography>{plotInformation.caption ?? '[Caption]'}</Typography>
         <br />
         <Typography>{generatePlotInformationText()}</Typography>
       </Box>
     ) : (
       <Box tabIndex={tabIndex}>
-        <Button 
-          tabIndex={tabIndex + 6} 
-          color="primary" 
-          style={{float: 'right'}} 
+        <Button
+          tabIndex={tabIndex + 6}
+          color="primary"
+          style={{ float: 'right' }}
           onClick={commitEdits}
-        >Save</Button>
+        >
+          Save
+        </Button>
         <Box>
           <TextField
-            tabIndex={tabIndex + 1} 
-            fullWidth 
-            variant='standard'
-            style={{marginBottom: "5px"}}
+            tabIndex={tabIndex + 1}
+            fullWidth
+            variant="standard"
+            style={{ marginBottom: '5px' }}
             value={plotInformation.title}
             onChange={(e) => setPlotInformation({ ...plotInformation, title: e.target.value })}
-            placeholder='Title'
+            placeholder="Title"
             inputProps={{
               disableUnderline: true,
               style: {
-                padding: "1px", 
-                height: "1.4em", 
-                fontSize: "1.2em", 
-                fontWeight: "inherit",
-                border: "none",
-            }}}/>
-          <TextField 
+                padding: '1px',
+                height: '1.4em',
+                fontSize: '1.2em',
+                fontWeight: 'inherit',
+                border: 'none',
+              },
+            }}
+          />
+          <TextField
             tabIndex={tabIndex + 2}
-            fullWidth multiline
+            fullWidth
+            multiline
             inputProps={{
               rows: 3,
               // We need to override the default overflow prop (hidden), then still deny x scrolling
-              style: {height: "4em", overflow: "auto", overflowX: "hidden"}
+              style: { height: '4em', overflow: 'auto', overflowX: 'hidden' },
             }}
             value={plotInformation.caption}
             onChange={(e) => setPlotInformation({ ...plotInformation, caption: e.target.value })}
-            placeholder='Caption'
+            placeholder="Caption"
           />
         </Box>
         <Box>
@@ -190,7 +197,7 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
             <TextField
               tabIndex={tabIndex + 3}
               onChange={(e) => setPlotInformation({ ...plotInformation, description: e.target.value })}
-              sx={{ width: 100 - fieldTitleWidth + '%' }}
+              sx={{ width: `${100 - fieldTitleWidth}%` }}
               multiline
               InputLabelProps={{ shrink: true }}
               value={plotInformation.description}
@@ -208,7 +215,7 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
             <TextField
               tabIndex={tabIndex + 4}
               onChange={(e) => setPlotInformation({ ...plotInformation, sets: e.target.value })}
-              sx={{ width: 100 - fieldTitleWidth + '%' }}
+              sx={{ width: `${100 - fieldTitleWidth}%` }}
               multiline
               InputLabelProps={{ shrink: true }}
               value={plotInformation.sets}
@@ -226,7 +233,7 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
             <TextField
               tabIndex={tabIndex + 5}
               onChange={(e) => setPlotInformation({ ...plotInformation, items: e.target.value })}
-              sx={{ width: 100 - fieldTitleWidth + '%' }}
+              sx={{ width: `${100 - fieldTitleWidth}%` }}
               multiline
               InputLabelProps={{ shrink: true }}
               value={plotInformation.items}
@@ -239,5 +246,5 @@ export const PlotInformation = ({onSave, divider, tabIndex}: Props) => {
         <Typography>{generatePlotInformationText()}</Typography>
       </Box>
     )
-  )
-}
+  );
+};

--- a/packages/upset/src/types.ts
+++ b/packages/upset/src/types.ts
@@ -107,6 +107,11 @@ export interface UpsetProps {
   config?: Partial<UpsetConfig>;
 
   /**
+   * Indicates if the user is an admin or owner of the workspace. This is used to determine if the user can make edits to the plot information. Defaults to true.
+   */
+  userEditPerms?: boolean;
+
+  /**
   * List of attribute names (strings) which should be visualized.
   * Defaults to the first 3 if no value is provided.
   * If an empty list is provided, displays no attributes.


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #328 

### Give a longer description of what this PR addresses and why it's needed
This PR adds permissions logic for user edits of the accessibility sidebar. This includes Plot Information and the User text description.

Desired behavior:
When the user is NOT logged into an admin (maintainer) or owner account, they are unable to edit the plot information or text description. They CAN still toggle between long and short description, as this is not a state action and is still useful for accessibility.
When the user IS logged in, the accessibility sidebar functions without any limitations. Plot information is editable and text descriptions are editable.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Update tests
- [ ] Accessibility concerns? Aria-disabled required, or is this handled natively by disabled objects?
