### PR TITLE
Fix deviation scale being shifted by 1/2 attribute bar width

### DIFF
--- a/packages/upset/src/components/Columns/DeviationBar.tsx
+++ b/packages/upset/src/components/Columns/DeviationBar.tsx
@@ -18,7 +18,7 @@ export const DeviationBar: FC<Props> = ({ deviation }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
 
   const deviationScale = useRecoilValue(deviationScaleAtom);
-  deviationScale.range([0, dimensions.attribute.width / 2]);
+  deviationScale.range([0, dimensions.attribute.width]);
 
   return (
     <g
@@ -30,11 +30,11 @@ export const DeviationBar: FC<Props> = ({ deviation }) => {
       <rect
         fill={(deviation > 0) ? positiveDeviation : negativeDeviation}
         transform={translate(
-          deviation > 0 ? 0 : -deviationScale(Math.abs(deviation)),
+          deviation > 0 ? 0 : -deviationScale(Math.abs(deviation)) + dimensions.attribute.width / 2,
           0,
         )}
         height={dimensions.attribute.plotHeight}
-        width={deviationScale(Math.abs(deviation))}
+        width={deviationScale(Math.abs(deviation)) - dimensions.attribute.width / 2}
       />
     </g>
   );


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #386 

### Give a longer description of what this PR addresses and why it's needed
This PR fixes a deviation bar scale issue. The bar was scaled using `dimensions.attribute.width / 2` when it needed to be `dimensions.attribute.width`. This was causing near 0 values to always go out to halfway to the maximum bar size.

### Provide pictures/videos of the behavior before and after these changes (optional)
**BEFORE**: 
![image](https://github.com/user-attachments/assets/6ffb732a-da5e-4666-beeb-21635e2caae4)

**AFTER**:
![image](https://github.com/user-attachments/assets/6230928a-9335-4b04-9add-9e1e87547ebb)


*note*: The numbers only appear as part of the debugging process.

### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
