### PR TITLE
Update default values for the plot information text

### DIFF
--- a/packages/upset/src/components/custom/PlotInformation.tsx
+++ b/packages/upset/src/components/custom/PlotInformation.tsx
@@ -74,6 +74,11 @@ export const PlotInformation = ({
     sets: 'name for the sets in this data, eg: "movie genres"',
     items: 'name for the items in this data, eg: "movies"',
   };
+  const defaultPlotInformation = {
+    description: '[dataset description]',
+    sets: '[set names]',
+    items: '[item names]',
+  };
 
   /**
    * State
@@ -94,7 +99,7 @@ export const PlotInformation = ({
   const generatePlotInformationText: () => string = useCallback(() => {
     // return default string if there are no values filled in
     if (Object.values(plotInformation).filter((a) => a && a.length > 0).length === 0) {
-      return `This UpSet plot shows ${placeholderText.description}. The sets are ${placeholderText.sets}. The items are ${placeholderText.items}`;
+      return `This UpSet plot shows ${defaultPlotInformation.description}. The sets are ${defaultPlotInformation.sets}. The items are ${defaultPlotInformation.items}`;
     }
 
     let str: string = '';
@@ -109,7 +114,7 @@ export const PlotInformation = ({
     }
 
     return str;
-  }, [plotInformation, placeholderText]);
+  }, [plotInformation, defaultPlotInformation]);
 
   /**
    * Commits changes to the plot information if the new state is different from the old state.


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Updates the default plot information text to be more comprehensible. 

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![image](https://github.com/user-attachments/assets/90597a08-0886-485f-889a-3990b4f80c3b)
After:
<img width="448" alt="Screenshot 2024-09-04 at 2 39 59 PM" src="https://github.com/user-attachments/assets/1297c088-d246-45a4-a9b0-5c1d6aff9ce6">


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
No