### PR TITLE
Only generate alttext if sidebar is open

### DIFF
--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -115,7 +115,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       }
     }
 
-    generate();
+    if (open) generate();
   }, [currState]);
 
   /**


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #353 

### Give a longer description of what this PR addresses and why it's needed
Minor optimization: only generates the alttext if the Text Descriptions sidebar is open.

### Provide pictures/videos of the behavior before and after these changes (optional)
No visible change in behavior.

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
