### PR TITLE
402 add bgrect collapse

### DIFF
--- a/e2e-tests/provenance.spec.ts
+++ b/e2e-tests/provenance.spec.ts
@@ -24,9 +24,9 @@ test('Selection History', async ({ page }) => {
 
   // Testing history for an aggregate row selection & deselection
   await page.getByRole('radio', { name: 'Degree' }).check();
-  await page.locator('g').filter({ hasText: /^Degree 3Degree 3$/ }).locator('rect').click();
+  await page.locator('g').filter({ hasText: /^Degree 3Degree 3$/ }).locator('rect').nth(0).click();
   await expect(page.locator('div').filter({ hasText: /^Select intersection "Degree 3"$/ }).nth(2)).toBeVisible();
-  await page.locator('g').filter({ hasText: /^Degree 3Degree 3$/ }).locator('rect').click();
+  await page.locator('g').filter({ hasText: /^Degree 3Degree 3$/ }).locator('rect').nth(0).click();
   await expect(page.getByText('Deselect intersection').nth(1)).toBeVisible();
 
   // Check that selections are maintained after de-aggregation

--- a/packages/upset/src/components/Rows/AggregateRow.tsx
+++ b/packages/upset/src/components/Rows/AggregateRow.tsx
@@ -7,7 +7,10 @@ import SvgIcon from '@mui/material/SvgIcon';
 
 import { visibleSetSelector } from '../../atoms/config/visibleSetsAtoms';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
-import { bookmarkSelector, currentIntersectionSelector } from '../../atoms/config/currentIntersectionAtom';
+import {
+  bookmarkSelector,
+  currentIntersectionSelector,
+} from '../../atoms/config/currentIntersectionAtom';
 import translate from '../../utils/transform';
 import { highlight, mousePointer } from '../../utils/styles';
 import { SizeBar } from '../Columns/SizeBar';
@@ -43,7 +46,15 @@ const expanded = (
  * Collapsed icon for the AggregateRow component.
  */
 export const collapsed = (
-  <g transform={`rotate(180) translate(-${iconSize.replace('px', '')}, -${iconSize.replace('px', '')})`} className="icon" textAnchor="middle" dominantBaseline="middle">
+  <g
+    transform={`rotate(180) translate(-${iconSize.replace(
+      'px',
+      '',
+    )}, -${iconSize.replace('px', '')})`}
+    className="icon"
+    textAnchor="middle"
+    dominantBaseline="middle"
+  >
     <SvgIcon height={iconSize} width={iconSize}>
       <KeyboardArrowDownIcon />
     </SvgIcon>
@@ -85,19 +96,28 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
   return (
     <g
       id={aggregateRow.id}
-      onClick={() => aggregateRow &&
-        (currentIntersection?.id === aggregateRow.id ?
-          actions.setSelected(null) : actions.setSelected(aggregateRow))}
+      onClick={() =>
+        aggregateRow &&
+        (currentIntersection?.id === aggregateRow.id
+          ? actions.setSelected(null)
+          : actions.setSelected(aggregateRow))
+      }
       css={mousePointer}
     >
-      <g transform={translate(aggregateRow.level === 2 ? secondLevelXOffset : 2, 0)}>
+      <g
+        transform={translate(
+          aggregateRow.level === 2 ? secondLevelXOffset : 2,
+          0,
+        )}
+      >
         <rect
           transform={translate(0, 2)}
-          css={
-            (currentIntersection?.id === aggregateRow.id) &&
-              highlight
+          css={currentIntersection?.id === aggregateRow.id && highlight}
+          height={
+            ['Sets', 'Overlaps'].includes(aggregateRow.aggregateBy)
+              ? (dimensions.body.rowHeight - 4) * 2
+              : dimensions.body.rowHeight - 4
           }
-          height={(['Sets', 'Overlaps'].includes(aggregateRow.aggregateBy)) ? (dimensions.body.rowHeight - 4) * 2 : dimensions.body.rowHeight - 4}
           width={width}
           rx={5}
           ry={10}
@@ -106,16 +126,21 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
           stroke="#555555"
           strokeWidth="1px"
         />
-        <g
-          onClick={() => {
-            if (collapsedIds.includes(aggregateRow.id)) {
-              actions.removeCollapsed(aggregateRow.id);
-            } else {
-              actions.addCollapsed(aggregateRow.id);
-            }
-          }}
-        >
-          { collapsedIds.includes(aggregateRow.id) ? collapsed : expanded}
+        <g>
+          {collapsedIds.includes(aggregateRow.id) ? collapsed : expanded}
+          {/* onclick background element */}
+          <rect
+            width={iconSize}
+            height={iconSize}
+            fill="transparent"
+            onClick={() => {
+              if (collapsedIds.includes(aggregateRow.id)) {
+                actions.removeCollapsed(aggregateRow.id);
+              } else {
+                actions.addCollapsed(aggregateRow.id);
+              }
+            }}
+          />
         </g>
         <text
           css={css`
@@ -138,14 +163,24 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
           />
         </g>
       )}
-      <g transform={translate(0, (['Sets', 'Overlaps'].includes(aggregateRow.aggregateBy)) ? dimensions.body.rowHeight - 5 : 0)}>
+      <g
+        transform={translate(
+          0,
+          ['Sets', 'Overlaps'].includes(aggregateRow.aggregateBy)
+            ? dimensions.body.rowHeight - 5
+            : 0,
+        )}
+      >
         <BookmarkStar row={aggregateRow} />
         <SizeBar
           row={aggregateRow}
           size={aggregateRow.size}
           selected={selected}
         />
-        <AttributeBars attributes={aggregateRow.attributes} row={aggregateRow} />
+        <AttributeBars
+          attributes={aggregateRow.attributes}
+          row={aggregateRow}
+        />
       </g>
     </g>
   );

--- a/packages/upset/src/components/Rows/AggregateRow.tsx
+++ b/packages/upset/src/components/Rows/AggregateRow.tsx
@@ -133,7 +133,8 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
             width={iconSize}
             height={iconSize}
             fill="transparent"
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               if (collapsedIds.includes(aggregateRow.id)) {
                 actions.removeCollapsed(aggregateRow.id);
               } else {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #402 

### Give a longer description of what this PR addresses and why it's needed
This PR adds a background rect object to the aggregate row collapse/expand icon. This expands the clickable area for the icon. Additionally, this PR halts the click propagation when clicking on the collapse icon. Basically, the row no longer gets selected when the row is collapsed or expanded.

### Provide pictures/videos of the behavior before and after these changes (optional)
BEFORE:
![upset-bg-rect-aggrows-BEFORE](https://github.com/user-attachments/assets/994f0887-a088-4751-8f31-401de298781e)

AFTER:
![upset-bg-rect-aggrows](https://github.com/user-attachments/assets/a46cfc37-99c8-46d2-9d3c-508ebeee4268)


### Have you added or updated relevant tests?
- [X] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] Fill in before/after videos
- [X] Update tests
