### PR TITLE
Add set membership columns to the element view table

### DIFF
--- a/e2e-tests/elementView.spec.ts
+++ b/e2e-tests/elementView.spec.ts
@@ -77,7 +77,9 @@ test('Element View', async ({ page, browserName }) => {
   await expect(selectionChip).toBeVisible();
 
   // Check that the datatable is visible and populated
-  const dataTable = page.locator('div').filter({ hasText: /^LabelAge$/ }).first();
+  const dataTable = page.getByText(
+    'LabelAgeSchoolBlue HairDuff FanEvilMalePower PlantBart10yesnononoyesnoRalph8yesnononoyesnoMartin Prince10yesnononoyesnoRows per page:1001–3 of',
+  );
   await expect(dataTable).toBeVisible();
   const nameCell = await page.getByRole('cell', { name: 'Bart' });
   await expect(nameCell).toBeVisible();

--- a/packages/upset/src/atoms/dataAtom.ts
+++ b/packages/upset/src/atoms/dataAtom.ts
@@ -22,3 +22,14 @@ export const queryColumnsSelector = selector<ColumnName[]>({
       && !BUILTIN_COLS.includes(col));
   },
 });
+
+/**
+ * Returns the boolean columns that indicate set membership
+ */
+export const setColumnsSelector = selector<ColumnName[]>({
+  key: 'set-columns',
+  get: ({ get }) => {
+    const data = get(dataAtom);
+    return data.setColumns;
+  },
+});

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -41,12 +41,12 @@ function useColumns(columns: string[]) {
  * Table to display elements
  */
 export const ElementTable: FC = () => {
-  const attColumns = useRecoilValue(attributeAtom);
+  const attributeColumns = useRecoilValue(attributeAtom);
   const elements = useRecoilValue(selectedItemsSelector);
   const rows = useRows(elements);
   const setColumns = useRecoilValue(setColumnsSelector);
-  let columns = useColumns(['_label', ...([...attColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
-  // Sort set columns to the right of other columns & add a boolean type to
+  let columns = useColumns(['_label', ...([...attributeColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
+  // Add a boolean type to set columns so they display properly
   columns = columns.map((col) => ({
     ...col,
     type: setColumns.includes(col.field) ? 'boolean' : 'string',

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -5,7 +5,6 @@ import { FC, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { selectedItemsSelector } from '../../atoms/elementsSelectors';
-import { columnsAtom } from '../../atoms/columnAtom';
 import { setColumnsSelector } from '../../atoms/dataAtom';
 import { attributeAtom } from '../../atoms/attributeAtom';
 

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -4,8 +4,9 @@ import { Item } from '@visdesignlab/upset2-core';
 import { FC, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { attributeAtom } from '../../atoms/attributeAtom';
 import { selectedItemsSelector } from '../../atoms/elementsSelectors';
+import { columnsAtom } from '../../atoms/columnAtom';
+import { setColumnsSelector } from '../../atoms/dataAtom';
 
 /**
  * Hook to generate rows for the DataGrid
@@ -40,10 +41,27 @@ function useColumns(columns: string[]) {
  * Table to display elements
  */
 export const ElementTable: FC = () => {
-  const attributeColumns = useRecoilValue(attributeAtom);
+  const allColumns = useRecoilValue(columnsAtom);
   const elements = useRecoilValue(selectedItemsSelector);
   const rows = useRows(elements);
-  const columns = useColumns(['_label', ...attributeColumns]);
+  const setColumns = useRecoilValue(setColumnsSelector);
+  let columns = useColumns(['_label', ...allColumns.filter((col) => !col.startsWith('_'))]);
+  // Sort set columns to the right of other columns & add a boolean type to
+  columns = columns.sort((a, b) => {
+    if (setColumns.includes(a.field) && setColumns.includes(b.field)) {
+      return 0;
+    }
+    if (setColumns.includes(a.field)) {
+      return 1;
+    }
+    if (setColumns.includes(b.field)) {
+      return -1;
+    }
+    return 0;
+  }).map((col) => ({
+    ...col,
+    type: setColumns.includes(col.field) ? 'boolean' : 'string',
+  }));
 
   return (
     <Box

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -7,6 +7,7 @@ import { useRecoilValue } from 'recoil';
 import { selectedItemsSelector } from '../../atoms/elementsSelectors';
 import { columnsAtom } from '../../atoms/columnAtom';
 import { setColumnsSelector } from '../../atoms/dataAtom';
+import { attributeAtom } from '../../atoms/attributeAtom';
 
 /**
  * Hook to generate rows for the DataGrid
@@ -41,24 +42,13 @@ function useColumns(columns: string[]) {
  * Table to display elements
  */
 export const ElementTable: FC = () => {
-  const allColumns = useRecoilValue(columnsAtom);
+  const attColumns = useRecoilValue(attributeAtom);
   const elements = useRecoilValue(selectedItemsSelector);
   const rows = useRows(elements);
   const setColumns = useRecoilValue(setColumnsSelector);
-  let columns = useColumns(['_label', ...allColumns.filter((col) => !col.startsWith('_'))]);
+  let columns = useColumns(['_label', ...([...attColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
   // Sort set columns to the right of other columns & add a boolean type to
-  columns = columns.sort((a, b) => {
-    if (setColumns.includes(a.field) && setColumns.includes(b.field)) {
-      return 0;
-    }
-    if (setColumns.includes(a.field)) {
-      return 1;
-    }
-    if (setColumns.includes(b.field)) {
-      return -1;
-    }
-    return 0;
-  }).map((col) => ({
+  columns = columns.map((col) => ({
     ...col,
     type: setColumns.includes(col.field) ? 'boolean' : 'string',
   }));


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #399

### Give a longer description of what this PR addresses and why it's needed
Adds boolean columns (showing X or ✓) for each set to the query result table, indicating the set membership of each element.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![309-before](https://github.com/user-attachments/assets/34c9247b-bf7a-42c2-b907-9b4c47559238)
After:
![309-after](https://github.com/user-attachments/assets/d1413d79-3e28-4f57-a98c-c9a037bdcbba)


### Have you added or updated relevant tests?
- [x] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed