### PR TITLE
Proper ellipsis truncation of set names

### DIFF
--- a/packages/upset/src/components/custom/SetLabel.tsx
+++ b/packages/upset/src/components/custom/SetLabel.tsx
@@ -12,6 +12,9 @@ type Props = {
   name: string;
 };
 
+/**
+ * Label for the sets at the top of the membership matrix
+ */
 export const SetLabel: FC<Props> = ({ setId, name }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const columnHover = useRecoilValue(columnHoverAtom);
@@ -45,7 +48,6 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
           color: '#000000',
           fontSize: '14px',
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
         }}
 
       >
@@ -55,6 +57,10 @@ export const SetLabel: FC<Props> = ({ setId, name }) => {
           margin: '2px 0 0 0',
           fontWeight: '500',
           textAlign: 'start',
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          width: dimensions.set.label.height - gap,
         }}
         >
           {name}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #355 

### Give a longer description of what this PR addresses and why it's needed
Ensures that an ellipsis is used to truncate set names when the length exceeds the size of the set label above the membership matrix.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="126" alt="Screenshot 2025-01-27 at 1 37 50 PM" src="https://github.com/user-attachments/assets/13ee19a5-e17b-42b8-bf7f-5960dc55547d" />

After:
<img width="125" alt="Screenshot 2025-01-27 at 1 37 19 PM" src="https://github.com/user-attachments/assets/372060c9-3f42-4f68-bd65-4729ee5864a6" />

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed
