### PR TITLE
Jan '25 Updates to Alttext Sidebar Styles

### DIFF
--- a/packages/app/src/components/AccessiblityStatement.tsx
+++ b/packages/app/src/components/AccessiblityStatement.tsx
@@ -32,7 +32,7 @@ export const AccessibilityStatement = ({ open, close, data }: Props) => {
           The Visualization Design Lab at the University of Utah is committed to ensuring accessibility for all individuals, including those with disabilities.
           We strive to make our software user-friendly, accessible, and compliant with the
           {' '}
-          <Link href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noreferrer" aria-label="Read more about web content accessibility guidelines">Web Content Accessibility Guidelines (WCAG)</Link>
+          <Link href="https://www.w3.org/TR/WCAG21/" style={{ color: 'blue' }} target="_blank" rel="noreferrer" aria-label="Read more about web content accessibility guidelines">Web Content Accessibility Guidelines (WCAG)</Link>
           {' '}
           2.1 Level AA.
         </p>
@@ -70,7 +70,7 @@ export const AccessibilityStatement = ({ open, close, data }: Props) => {
         <p>
           To report any accessibility issues you may encounter or to provide suggestions for improvement, please contact us at
           {' '}
-          <Link type="email" href="mailto:vdl-faculty@sci.utah.edu" aria-label="VDL faculty email">vdl-faculty@sci.utah.edu</Link>
+          <Link type="email" style={{ color: 'blue' }} href="mailto:vdl-faculty@sci.utah.edu" aria-label="VDL faculty email">vdl-faculty@sci.utah.edu</Link>
           .
           We value your feedback and are committed to continuously enhancing the accessibility and usability of our software.
         </p>

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -182,7 +182,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
           ) : null
         )}
       {displayPlotInfo && (
-      <UpsetHeading level="h2">Text Description</UpsetHeading>
+      <UpsetHeading level="h2" style={{ marginTop: '10px' }}>Text Description</UpsetHeading>
       )}
       {/* 0.875em for default 16px = 1em makes 14px, which is the standard for much of the UI */}
       <Box style={{ overflowY: 'auto', fontSize: '0.875em' }}>

--- a/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
+++ b/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@mui/material';
 import Markdown from 'react-markdown';
 
 // Wrapper for the Markdown component to parse and render the alt-txt json
@@ -5,6 +6,8 @@ export default function ReactMarkdownWrapper({ text }: { text: string }) {
   const components = {
     // eslint-disable-next-line react/no-unstable-nested-components, jsx-a11y/heading-has-content
     h1: ({ node, ...props }: { node: any }) => <h3 id={node.children[0].value} {...props} />,
+    // eslint-disable-next-line react/no-unstable-nested-components, jsx-a11y/heading-has-content
+    p: ({ node, ...props }: { node: any }) => <Typography {...props} />,
   };
 
   return (

--- a/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
+++ b/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@mui/material';
 import Markdown from 'react-markdown';
+import '../../index.css';
 
 // Wrapper for the Markdown component to parse and render the alt-txt json
 export default function ReactMarkdownWrapper({ text }: { text: string }) {
@@ -8,6 +9,12 @@ export default function ReactMarkdownWrapper({ text }: { text: string }) {
     h1: ({ node, ...props }: { node: any }) => <h3 id={node.children[0].value} {...props} />,
     // eslint-disable-next-line react/no-unstable-nested-components, jsx-a11y/heading-has-content
     p: ({ node, ...props }: { node: any }) => <Typography {...props} />,
+    // eslint-disable-next-line react/no-unstable-nested-components, jsx-a11y/heading-has-content
+    ul: ({ node, ...props }: { node: any }) => <ul
+      {...props}
+      // Matches the MUI typography style used for p elements
+      style={{ paddingLeft: '20px', lineHeight: 1.5, fontSize: '0.9rem' }}
+    />,
   };
 
   return (


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #444 
Closes #445 
Closes #446 
Closes #447 

### Give a longer description of what this PR addresses and why it's needed
Adds top margin to the Text Description header, fixes bullet point padding in the text description, makes line height and font size consistent between the text description & caption, and makes the accessibility statement links blue.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="459" alt="Screenshot 2025-01-29 at 10 16 56 AM" src="https://github.com/user-attachments/assets/d9ebdef7-d8bb-43a0-ae15-77d1b6ee0602" />

After:
<img width="459" alt="Screenshot 2025-01-29 at 10 16 11 AM" src="https://github.com/user-attachments/assets/08f0eadc-2aec-4a78-9790-1bfb07fe31b1" />


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed
