### PR TITLE
Element View UI Updates

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report

--- a/e2e-tests/elementView.spec.ts
+++ b/e2e-tests/elementView.spec.ts
@@ -67,7 +67,7 @@ test('Element View', async ({ page, browserName }) => {
   await expect(elementViewHeading).toBeVisible();
   const elementQueriesHeading = await page.getByRole('heading', { name: 'Element Queries' });
   await expect(elementQueriesHeading).toBeVisible();
-  const elementVisualizationHeading = await page.getByRole('heading', { name: 'Element Visualization' });
+  const elementVisualizationHeading = await page.getByRole('heading', { name: 'Element View' });
   await expect(elementVisualizationHeading).toBeVisible();
   const queryResultHeading = await page.getByRole('heading', { name: 'Query Result' });
   await expect(queryResultHeading).toBeVisible();
@@ -86,7 +86,7 @@ test('Element View', async ({ page, browserName }) => {
   await expect(ageCell).toBeVisible();
 
   // Check that the add plot button is visible
-  const addPlot = await page.getByRole('button', { name: 'Add Plot' });
+  const addPlot = await page.locator('.MuiPaper-root > div:nth-child(2) > button').first();
   await expect(addPlot).toBeVisible();
   await addPlot.click();
 
@@ -185,8 +185,7 @@ test('Element View', async ({ page, browserName }) => {
   /*
     * Plot removal
     */
-  await page.locator('div').filter({ hasText: /^Add Plot$/ }).getByRole('button').nth(1)
-    .click();
+  await page.locator('.MuiBox-root > .MuiBox-root > .MuiButtonBase-root').first().click();
   await expect(page.locator('canvas')).not.toBeVisible();
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -224,8 +224,17 @@ export type Rows = Subsets | Aggregates;
  */
 export type Row = Subset | Aggregate;
 
+/**
+ * Possible column types.
+ * @private Taken from the TableTypeAnnotation in multinet-api
+ */
+export type ColumnType = 'primary key' | 'edge source' | 'edge target' | 'label' | 'string' | 'boolean' | 'category' | 'number' | 'date' | 'ignored';
+
+/**
+ * Maps column names to their string type
+ */
 export type ColumnTypes = {
-    [key: string]: string;
+    [key: string]: ColumnType;
 }
 
 export type CoreUpsetData = {
@@ -297,6 +306,17 @@ export enum ElementQueryType {
   CONTAINS = 'contains',
   LENGTH = 'length equals',
   REGEX = 'regex',
+  LESS_THAN = 'less than',
+  GREATER_THAN = 'greater than',
+}
+
+/**
+ * Possible string types for an element query on a numerical attribute
+ */
+// linter is saying this is already declared... on this line
+// eslint-disable-next-line no-shadow
+export enum NumericalQueryType {
+  EQUALS = 'equals',
   LESS_THAN = 'less than',
   GREATER_THAN = 'greater than',
 }

--- a/packages/upset/src/atoms/attributeAtom.ts
+++ b/packages/upset/src/atoms/attributeAtom.ts
@@ -1,6 +1,8 @@
 import { atom, selector, selectorFamily } from 'recoil';
 
+import { ColumnTypes } from '@visdesignlab/upset2-core';
 import { itemsAtom } from './itemsAtoms';
+import { dataAtom } from './dataAtom';
 
 /**
  * All attributes, including degree and deviation
@@ -8,6 +10,15 @@ import { itemsAtom } from './itemsAtoms';
 export const attributeAtom = atom<string[]>({
   key: 'attribute-columns',
   default: [],
+});
+
+/**
+ * Types of all attributes
+ * @returns {ColumnTypes} Object with attribute names as keys and their types as values
+ */
+export const attTypesSelector = selector<ColumnTypes>({
+  key: 'attribute-types',
+  get: ({ get }) => get(dataAtom).columnTypes,
 });
 
 /**

--- a/packages/upset/src/components/ElementView/BookmarkChips.tsx
+++ b/packages/upset/src/components/ElementView/BookmarkChips.tsx
@@ -2,7 +2,7 @@ import SquareIcon from '@mui/icons-material/Square';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { Chip, Stack } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import {
@@ -52,8 +52,15 @@ export const BookmarkChips = () => {
     }
   }
 
+  /** Whether there is at least 1 chip */
+  const hasChip = useMemo(
+    () => currentIntersection || currentSelection || bookmarked.length > 0,
+    [currentIntersection, currentSelection, bookmarked],
+  );
+
   return (
-    <Stack direction="row" sx={{ flexFlow: 'row wrap' }}>
+    // Silly goofy stack treats minHeight as maxHeight when we have chips... why??? idk
+    <Stack direction="row" sx={{ flexFlow: 'row wrap', minHeight: hasChip ? undefined : '40px' }}>
       {/* All chips from bookmarks */}
       {bookmarked.map((bookmark) => (
         <Chip

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -5,7 +5,8 @@ import {
 import { Item } from '@visdesignlab/upset2-core';
 import { useRecoilValue } from 'recoil';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import AddchartIcon from '@mui/icons-material/Addchart';
 import { columnsAtom } from '../../atoms/columnAtom';
 import {
   selectedElementSelector, selectedItemsCounter,
@@ -18,6 +19,7 @@ import { QueryInterface } from './QueryInterface';
 import { bookmarkSelector, currentIntersectionSelector } from '../../atoms/config/currentIntersectionAtom';
 import { Sidebar } from '../custom/Sidebar';
 import { UpsetHeading } from '../custom/theme/heading';
+import { AddPlotDialog } from './AddPlotDialog';
 
 /**
  * Props for the ElementSidebar component
@@ -71,6 +73,7 @@ function downloadElementsAsCSV(items: Item[], columns: string[], name: string) {
  * @param close Function to close the sidebar
  */
 export const ElementSidebar = ({ open, close }: Props) => {
+  const [openAddPlot, setOpenAddPlot] = useState(false);
   const currentElementSelection = useRecoilValue(selectedElementSelector);
   const selectedItems = useRecoilValue(selectedItemsSelector);
   const itemCount = useRecoilValue(selectedItemsCounter);
@@ -84,8 +87,22 @@ export const ElementSidebar = ({ open, close }: Props) => {
     [bookmarked.length, currentIntersection, currentElementSelection],
   );
 
+  /**
+   * Closes the AddPlotDialog
+   */
+  const onClose = useCallback(() => setOpenAddPlot(false), [setOpenAddPlot]);
+
   return (
-    <Sidebar open={open} close={close} label="Element View Sidebar">
+    <Sidebar
+      open={open}
+      close={close}
+      label="Element View Sidebar"
+      buttons={
+        <IconButton onClick={() => setOpenAddPlot(true)}>
+          <AddchartIcon />
+        </IconButton>
+      }
+    >
       <div style={{ marginBottom: '1em' }}>
         <UpsetHeading level="h1">
           Element View
@@ -96,6 +113,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
       </UpsetHeading>
       <BookmarkChips />
       <ElementVisualization />
+      <AddPlotDialog open={openAddPlot} onClose={onClose} />
       <UpsetHeading level="h2" style={{ marginTop: '1em' }}>
         Element Queries
       </UpsetHeading>

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -98,9 +98,11 @@ export const ElementSidebar = ({ open, close }: Props) => {
       close={close}
       label="Element View Sidebar"
       buttons={
-        <IconButton onClick={() => setOpenAddPlot(true)}>
-          <AddchartIcon />
-        </IconButton>
+        <Tooltip title="Add Plot">
+          <IconButton onClick={() => setOpenAddPlot(true)}>
+            <AddchartIcon />
+          </IconButton>
+        </Tooltip>
       }
     >
       <div style={{ marginBottom: '1em' }}>

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -91,17 +91,10 @@ export const ElementSidebar = ({ open, close }: Props) => {
           Element View
         </UpsetHeading>
       </div>
-      {showQueries && (
-        <>
-          <UpsetHeading level="h2">
-            Bookmarked Queries
-          </UpsetHeading>
-          <BookmarkChips />
-        </>
-      )}
-      <UpsetHeading level="h2" style={{ marginTop: showQueries ? '1em' : undefined }}>
-        Element Visualization
+      <UpsetHeading level="h3">
+        {showQueries ? 'Selections' : 'Selections Will Appear Here'}
       </UpsetHeading>
+      <BookmarkChips />
       <ElementVisualization />
       <UpsetHeading level="h2" style={{ marginTop: '1em' }}>
         Element Queries

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -134,14 +134,14 @@ export const ElementVisualization = () => {
           <Box style={{ display: 'inline-block', position: 'relative' }}>
             <IconButton
               style={{
-                position: 'absolute', top: 0, left: 0, zIndex: 100, padding: 0,
+                position: 'absolute', top: 0, right: -15, zIndex: 100, padding: 0,
               }}
               onClick={() => {
                 actions.removePlot(plot);
                 views.current = views.current.filter(({ plot: p }) => p.id !== plot.id);
               }}
             >
-              <CloseIcon />
+              <CloseIcon fontSize="small" />
             </IconButton>
             <VegaLite
               spec={spec}

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -141,7 +141,7 @@ export const ElementVisualization = () => {
                 views.current = views.current.filter(({ plot: p }) => p.id !== plot.id);
               }}
             >
-              <CloseIcon color="primary" />
+              <CloseIcon />
             </IconButton>
             <VegaLite
               spec={spec}

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/system';
 import {
   useCallback,
-  useContext, useEffect, useMemo, useRef, useState,
+  useContext, useEffect, useMemo, useRef,
 } from 'react';
 import { VegaLite, View } from 'react-vega';
 import { useRecoilValue } from 'recoil';
@@ -11,13 +11,12 @@ import {
   NumericalQuery,
 } from '@visdesignlab/upset2-core';
 import {
-  Alert, Button, IconButton,
+  IconButton,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
-import { bookmarkSelector, currentIntersectionSelector, elementColorSelector } from '../../atoms/config/currentIntersectionAtom';
+import { elementColorSelector } from '../../atoms/config/currentIntersectionAtom';
 import { histogramSelector, scatterplotsSelector } from '../../atoms/config/plotAtoms';
 import { currentNumericalQuery, elementsInBookmarkSelector, selectedElementSelector } from '../../atoms/elementsSelectors';
-import { AddPlotDialog } from './AddPlotDialog';
 import { generateVegaSpec } from './generatePlotSpec';
 import { ProvenanceContext } from '../Root';
 import { UpsetActions } from '../../provenance';
@@ -58,16 +57,12 @@ export const ElementVisualization = () => {
   /**
    * External state
    */
-
-  const [openAddPlot, setOpenAddPlot] = useState(false);
   const scatterplots = useRecoilValue(scatterplotsSelector);
   const histograms = useRecoilValue(histogramSelector);
-  const bookmarked = useRecoilValue(bookmarkSelector);
   const items = useRecoilValue(elementsInBookmarkSelector);
   const numericalQuery = useRecoilValue(currentNumericalQuery);
   const elementSelection = useRecoilValue(selectedElementSelector);
   const selectColor = useRecoilValue(elementColorSelector);
-  const currentIntersection = useRecoilValue(currentIntersectionSelector);
   const { actions }: {actions: UpsetActions} = useContext(ProvenanceContext);
 
   /**
@@ -89,11 +84,6 @@ export const ElementVisualization = () => {
   /**
    * Functions
    */
-
-  /**
-   * Closes the AddPlotDialog
-   */
-  const onClose = () => setOpenAddPlot(false);
 
   /**
    * Saves brush bounds to state when the interactive brush is used.
@@ -135,20 +125,6 @@ export const ElementVisualization = () => {
         draftSelection.current = undefined;
       }}
     >
-      <Button style={{ marginTop: '0.5em' }} onClick={() => setOpenAddPlot(true)}>Add Plot</Button>
-      {!currentIntersection && bookmarked.length === 0 && (
-        <Alert
-          severity="info"
-          variant="outlined"
-          role="generic"
-          sx={{
-            alignItems: 'center', marginBottom: '0.5em', border: 'none', color: '#777777',
-          }}
-        >
-          Currently visualizing all elements. Clicking on an intersection will visualize only its elements.
-        </Alert>
-      )}
-      <AddPlotDialog open={openAddPlot} onClose={onClose} />
       <Box sx={{
         overflowX: 'auto', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-around',
       }}

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -1,7 +1,9 @@
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import CloseFullscreen from '@mui/icons-material/CloseFullscreen';
 import CloseIcon from '@mui/icons-material/Close';
-import { Box, Drawer, IconButton } from '@mui/material';
+import {
+  Box, Drawer, IconButton, Tooltip,
+} from '@mui/material';
 import React, {
   FC, PropsWithChildren, useCallback, useState,
 } from 'react';
@@ -119,38 +121,44 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
       >
         {buttons}
         { !fullWidth ?
-          <IconButton
-            style={BUTTON_DIMS} // Necessary so that the shadow remains square even when we change the font size
-            onClick={() => {
-              setFullWidth(true);
-            }}
-            aria-label="Expand the sidebar in full screen"
-          >
-            {/* CRAZY, I know. 1 font size px changes the icon SVG dimensions (square) by .75px. So this is
+          <Tooltip title="Expand to full screen">
+            <IconButton
+              style={BUTTON_DIMS} // Necessary so that the shadow remains square even when we change the font size
+              onClick={() => {
+                setFullWidth(true);
+              }}
+              aria-label="Expand the sidebar in full screen"
+            >
+              {/* CRAZY, I know. 1 font size px changes the icon SVG dimensions (square) by .75px. So this is
             EXACTLY the font size needed to get this icon SVG to be the same dimensions as the close button: 14x14 */}
-            <OpenInFullIcon style={{ fontSize: '18.67px' }} />
-          </IconButton>
+              <OpenInFullIcon style={{ fontSize: '18.67px' }} />
+            </IconButton>
+          </Tooltip>
           :
+          <Tooltip title="Reduce to normal size">
+            <IconButton
+              style={BUTTON_DIMS} // Not actually necessary (it's 40*40 by default) but it's here for consistency
+              onClick={() => {
+                if (fullWidth) {
+                  setFullWidth(false);
+                }
+              }}
+              aria-label="Reduce the sidebar to normal size"
+            >
+              <CloseFullscreen />
+            </IconButton>
+          </Tooltip>}
+        <Tooltip title="Close">
           <IconButton
-            style={BUTTON_DIMS} // Not actually necessary (it's 40*40 by default) but it's here for consistency
             onClick={() => {
-              if (fullWidth) {
-                setFullWidth(false);
-              }
+              close();
             }}
-            aria-label="Reduce the sidebar to normal size"
+            tabIndex={closeButtonTabIndex}
+            aria-label="Close the sidebar"
           >
-            <CloseFullscreen />
-          </IconButton>}
-        <IconButton
-          onClick={() => {
-            close();
-          }}
-          tabIndex={closeButtonTabIndex}
-          aria-label="Close the sidebar"
-        >
-          <CloseIcon />
-        </IconButton>
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
       </div>
       {children}
       <Box minHeight={footerHeight} />

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -17,6 +17,8 @@ type Props= {
   closeButtonTabIndex?: number;
   /** Aria-label for the sidebar */
   label: string;
+  /** Buttons to display at the top of the sidebar, left of the close & expand */
+  buttons?: React.ReactNode;
 }
 
 /** Dimension for the square button wrappers */
@@ -26,7 +28,7 @@ const BUTTON_DIMS = { height: '40px', width: '40px' };
  * A collapsible, right-sidebar for the plot
  */
 export const Sidebar: FC<PropsWithChildren<Props>> = ({
-  open, close, closeButtonTabIndex, children, label,
+  open, close, closeButtonTabIndex, children, label, buttons,
 }) => {
   /** Chosen so we don't get a horizontal scrollbar in the element view table */
   const INITIAL_DRAWER_WIDTH = 462;
@@ -115,6 +117,7 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
         display: 'flex', justifyContent: 'end', position: 'absolute', top: '20px', right: 0,
       }}
       >
+        {buttons}
         { !fullWidth ?
           <IconButton
             style={BUTTON_DIMS} // Necessary so that the shadow remains square even when we change the font size

--- a/packages/upset/src/components/custom/theme/heading.tsx
+++ b/packages/upset/src/components/custom/theme/heading.tsx
@@ -35,7 +35,7 @@ const LEVELS: {[level in HeadingLevel]: { fontSize: string; }} = {
 export const UpsetHeading: FC<PropsWithChildren<Props>> = ({
   level, paddingLeft, style, children,
 }) => {
-  const IS_MAJOR = level === 'h1' || level === 'h2';
+  const IS_MAJOR = level === 'h1' || level === 'h2' || level === 'h3';
 
   return (
     <div style={{ marginBottom: '.5em', ...style }}>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #453 
Closes #452 
Closes #454 

### Give a longer description of what this PR addresses and why it's needed
- Retitles 'bookmarked queries' to 'selections', changes this to 'Selections will appear here' when no selections exist (instead of not showing the header), and reduces this heading from h2 to h3
- Adds spacing equivalent to 1 row of bookmark chips below 'Selections will appear here' when no bookmark chips are present
- Moves Add Plot button to the sidebar header as an AddChart icon
- Removes the 'Element Visualization' header
- Changes remove plot 'X' button to grey, moves to right, and decreases size
- Filters element query types to <, >, and = when the selected attribute is numerical; disables the type picker until the attribute is selected
- Defaults the element query att name to the first attribute and the type to =

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![ev-before](https://github.com/user-attachments/assets/a6dbf45f-d4f7-49fa-ba68-61a46efa3e40)

After:
![ev-after](https://github.com/user-attachments/assets/1be8bd4c-5cc9-4eaf-b9a5-014cfbe00d53)

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed
