### PR TITLE
Attribute plot safari position fix

### DIFF
--- a/packages/upset/src/components/Columns/Attribute/AttributePlots/MemoizedDensityVega.tsx
+++ b/packages/upset/src/components/Columns/Attribute/AttributePlots/MemoizedDensityVega.tsx
@@ -39,7 +39,11 @@ export const MemoizedDensityVega: FC<Props> = memo(
     );
 
     return (
-      <VegaLite renderer="svg" spec={spec} actions={false} height={height} />
+      // @ts-expect-error: VegaLite plots render with position: relative, which breaks the layout in webkit (safari).
+      // This fix does NOT affect the layout in other browsers, and is necessary to prevent the layout from breaking in safari.
+      // Part of the reason this is necessary is because we are required to use !important to override the position property set by react-vega;
+      // However, react does NOT support !important in inline styles, so we have to use the css prop to apply the style.
+      <VegaLite renderer="svg" spec={spec} actions={false} height={height} css={{ position: 'initial !important' }} />
     );
   },
   // Instead of checking all values, we assume that equal length & equal first & last elements are sufficient


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #396 

### Give a longer description of what this PR addresses and why it's needed
This pull request addresses a layout issue in Safari for the `MemoizedDensityVega` component by modifying the `VegaLite` element's styling (position attribute). The change ensures compatibility across different browsers without affecting the layout in non-Safari browsers.

In truth, I am not sure why Safari is having issues with `position: relative`, as I initially expected it was an issue with us not using `-webkit-transform` or some similar webkit specific property.

Changes to improve browser compatibility:

* [`/components/Columns/Attribute/AttributePlots/MemoizedDensityVega.tsx`](diffhunk://#diff-ac3ee297ec34fff0e72cf5df384ee0ea87f4e530e8b1cea28089bcca069be9dcL42-R46): Added a CSS property to the `VegaLite` element to prevent layout issues in Safari, using `css={{ position: 'initial !important' }}` to override the position property set by `react-vega`.

### Provide pictures/videos of the behavior before and after these changes (optional)
BEFORE: (SAFARI)
<img width="1581" alt="image" src="https://github.com/user-attachments/assets/880eaeff-bbc3-41d9-8536-d91ce6ff9e59" />


AFTER: (SAFARI)

<img width="1581" alt="image" src="https://github.com/user-attachments/assets/c885f1e7-4015-4e1d-97c5-a2897ccc23cb" />

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- None
