### PR TITLE
Update upload-artifact action to version 4 in Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #468 

### Give a longer description of what this PR addresses and why it's needed
This pull request includes an update to the GitHub Actions workflow for Playwright tests. The most important change is the upgrade of the `actions/upload-artifact` action from version 3 to version 4.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### Provide pictures/videos of the behavior before and after these changes (optional)
None required

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- None
