### PR TITLE
In-plot tooltips

### DIFF
--- a/packages/upset/src/components/Columns/Attribute/AttributeBar.tsx
+++ b/packages/upset/src/components/Columns/Attribute/AttributeBar.tsx
@@ -3,6 +3,7 @@ import {
 } from '@visdesignlab/upset2-core';
 import React, { FC } from 'react';
 import { useRecoilValue } from 'recoil';
+import { Tooltip } from '@mui/material';
 import { attributeMinMaxSelector } from '../../../atoms/attributeAtom';
 import { dimensionsSelector } from '../../../atoms/dimensionsAtom';
 import { useScale } from '../../../hooks/useScale';
@@ -87,12 +88,33 @@ export const AttributeBar: FC<Props> = ({ attribute, summary, row }) => {
     return <BoxPlot scale={scale} summary={summary as SixNumberSummary} />;
   }
 
+  /**
+   * Round a number to 3 decimal places
+   */
+  function round3(num: number | undefined): number {
+    if (num === undefined) {
+      return NaN;
+    }
+    return Math.round(num * 1000) / 1000;
+  }
+
   return (
     <g transform={translate(0, dimensions.attribute.plotHeight / 2)}>
       {
         typeof summary === 'number' ?
           <DeviationBar deviation={summary} /> :
-          getAttributePlotToRender()
+          <Tooltip
+            title={
+              <div style={{ whiteSpace: 'pre-line' }}>
+                {`Q1: ${round3(summary.first)}\nMean: ${round3(summary.mean)}\nMedian: ${round3(summary.median)}\nQ3: ${round3(summary.third)}`}
+              </div>
+            }
+          >
+            {/* Wrapping <g> is necessary for the Tooltip to work (it needs a specific contained component that can take a ref) */}
+            <g>
+              {getAttributePlotToRender()}
+            </g>
+          </Tooltip>
       }
     </g>
   );

--- a/packages/upset/src/components/Columns/DeviationBar.tsx
+++ b/packages/upset/src/components/Columns/DeviationBar.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
+import { Tooltip } from '@mui/material';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 import { deviationScaleAtom } from '../../atoms/scaleAtoms';
 import translate from '../../utils/transform';
@@ -21,21 +22,23 @@ export const DeviationBar: FC<Props> = ({ deviation }) => {
   deviationScale.range([0, dimensions.attribute.width]);
 
   return (
-    <g
-      transform={translate(
-        dimensions.attribute.width / 2,
-        0,
-      )}
-    >
-      <rect
-        fill={(deviation > 0) ? positiveDeviation : negativeDeviation}
+    <Tooltip title={`${Math.round(deviation * 1000) / 1000}`}>
+      <g
         transform={translate(
-          deviation > 0 ? 0 : -deviationScale(Math.abs(deviation)) + dimensions.attribute.width / 2,
+          dimensions.attribute.width / 2,
           0,
         )}
-        height={dimensions.attribute.plotHeight}
-        width={deviationScale(Math.abs(deviation)) - dimensions.attribute.width / 2}
-      />
-    </g>
+      >
+        <rect
+          fill={(deviation > 0) ? positiveDeviation : negativeDeviation}
+          transform={translate(
+            deviation > 0 ? 0 : -deviationScale(Math.abs(deviation)) + dimensions.attribute.width / 2,
+            0,
+          )}
+          height={dimensions.attribute.plotHeight}
+          width={deviationScale(Math.abs(deviation)) - dimensions.attribute.width / 2}
+        />
+      </g>
+    </Tooltip>
   );
 };


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #430 

### Give a longer description of what this PR addresses and why it's needed
- Adds a tooltip on deviation bars giving the numerical deviation value
- Adds a tooltip on attribute plots giving Q1, Mean, Median, and Q3

### Provide pictures/videos of the behavior before and after these changes (optional)
Before: No tooltips
After:
![tooltips](https://github.com/user-attachments/assets/7c664dbd-75c9-4bdd-a4d5-cf520e1ac025)

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed