### PR TITLE
Fixes for plot columns

### DIFF
--- a/packages/upset/src/components/Columns/BookmarkStar.tsx
+++ b/packages/upset/src/components/Columns/BookmarkStar.tsx
@@ -1,6 +1,8 @@
 import { Row } from '@visdesignlab/upset2-core';
 import StarIcon from '@mui/icons-material/Star';
-import { FC, MouseEvent, useContext, useMemo, useState } from 'react';
+import {
+  FC, MouseEvent, useContext, useMemo, useState,
+} from 'react';
 import { useRecoilValue } from 'recoil';
 import { ProvenanceContext } from '../Root';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
@@ -9,6 +11,7 @@ import {
   bookmarkedColorSelector,
   isRowBookmarkedSelector,
 } from '../../atoms/config/currentIntersectionAtom';
+import { UpsetActions } from '../../provenance';
 
 type Props = {
   row: Row;
@@ -34,7 +37,7 @@ export const BookmarkStar: FC<Props> = ({ row }) => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const bookmarked = useRecoilValue(isRowBookmarkedSelector(row));
   const color = useRecoilValue(bookmarkedColorSelector(row));
-  const { actions } = useContext(ProvenanceContext);
+  const { actions }: {actions: UpsetActions} = useContext(ProvenanceContext);
 
   const rowDisplayName = row.elementName.replaceAll('~&~', ' & ') || '';
 
@@ -79,15 +82,17 @@ export const BookmarkStar: FC<Props> = ({ row }) => {
    */
   const handleClick = (event: MouseEvent<SVGGElement, MouseEvent>) => {
     event.stopPropagation();
+    const bookmark = {
+      id: row.id,
+      label: rowDisplayName,
+      size: row.size,
+      // Without 'as const' it complains that 'type' is a string instead of 'intersection' lol
+      type: 'intersection' as const,
+    };
     if (bookmarked) {
-      actions.removeBookmark(bookmarked);
+      actions.removeBookmark(bookmark);
     } else {
-      actions.addBookmark({
-        id: row.id,
-        label: rowDisplayName,
-        size: row.size,
-        type: 'intersection',
-      });
+      actions.addBookmark(bookmark);
     }
   };
 

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -79,6 +79,7 @@ export const Root: FC<Props> = ({
   const setContextMenu = useSetRecoilState(contextMenuAtom);
   const setAllowAttributeRemoval = useSetRecoilState(allowAttributeRemovalAtom);
 
+  // Set config. Note that the provenance passed in is ignored if a provenance is passed in
   useEffect(() => {
     if (!extProvenance) setState(convertConfig(config));
     setData(data);
@@ -111,7 +112,16 @@ export const Root: FC<Props> = ({
     return { provenance, actions };
   }, [config]);
 
-  useEffect(() => setState(convertConfig(provenance.getState())), []);
+  // Mandatory state defaults should go here
+  useEffect(() => {
+    const state = convertConfig(provenance.getState());
+    state.visibleAttributes.forEach((attr) => {
+      if (attr !== 'Degree' && attr !== 'Deviation' && !state.attributePlots[attr]) {
+        state.attributePlots = { ...state.attributePlots, [attr]: 'Box Plot' };
+      }
+    });
+    setState(state);
+  }, []);
 
   // This hook will populate initial sets, items, attributes
   useEffect(() => {

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -72,7 +72,7 @@ export const Root: FC<Props> = ({
   const setState = useSetRecoilState(upsetConfigAtom);
   const [sets, setSets] = useRecoilState(setsAtom);
   const [items, setItems] = useRecoilState(itemsAtom);
-  const setcanEditPlotInformation = useSetRecoilState(canEditPlotInformationAtom);
+  const setCanEditPlotInformation = useSetRecoilState(canEditPlotInformationAtom);
   const setAttributeColumns = useSetRecoilState(attributeAtom);
   const setAllColumns = useSetRecoilState(columnsAtom);
   const setData = useSetRecoilState(dataAtom);
@@ -86,7 +86,7 @@ export const Root: FC<Props> = ({
 
   useEffect(() => {
     if (canEditPlotInformation !== undefined) {
-      setcanEditPlotInformation(canEditPlotInformation);
+      setCanEditPlotInformation(canEditPlotInformation);
     }
   }, [canEditPlotInformation]);
 
@@ -122,7 +122,7 @@ export const Root: FC<Props> = ({
     setData(data);
     // if it is defined, pass through the provided value, else, default to true
     setAllowAttributeRemoval(allowAttributeRemoval !== undefined ? allowAttributeRemoval : true);
-  }, [data]);
+  }, [data, allowAttributeRemoval]);
 
   // close all open context menus
   const removeContextMenu = () => {

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-shadow */
 import { css } from '@emotion/react';
-import { convertConfig, CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
+import {
+  AttributePlotType, convertConfig, CoreUpsetData, UpsetConfig,
+} from '@visdesignlab/upset2-core';
 import {
   createContext, FC, useEffect, useMemo,
 } from 'react';
@@ -117,7 +119,7 @@ export const Root: FC<Props> = ({
     const state = convertConfig(provenance.getState());
     state.visibleAttributes.forEach((attr) => {
       if (attr !== 'Degree' && attr !== 'Deviation' && !state.attributePlots[attr]) {
-        state.attributePlots = { ...state.attributePlots, [attr]: 'Box Plot' };
+        state.attributePlots = { ...state.attributePlots, [attr]: AttributePlotType.DensityPlot };
       }
     });
     setState(state);

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-shadow */
 import { css } from '@emotion/react';
 import {
-  AttributePlotType, convertConfig, CoreUpsetData, UpsetConfig,
+  AttributePlotType, convertConfig, CoreUpsetData, deepCopy, UpsetConfig,
 } from '@visdesignlab/upset2-core';
 import {
   createContext, FC, useEffect, useMemo,
@@ -116,10 +116,10 @@ export const Root: FC<Props> = ({
 
   // Mandatory state defaults should go here
   useEffect(() => {
-    const state = convertConfig(provenance.getState());
+    const state = deepCopy(convertConfig(provenance.getState()));
     state.visibleAttributes.forEach((attr) => {
       if (attr !== 'Degree' && attr !== 'Deviation' && !state.attributePlots[attr]) {
-        state.attributePlots = { ...state.attributePlots, [attr]: AttributePlotType.DensityPlot };
+        state.attributePlots[attr] = AttributePlotType.DensityPlot;
       }
     });
     setState(state);

--- a/packages/upset/src/components/Upset.tsx
+++ b/packages/upset/src/components/Upset.tsx
@@ -14,7 +14,7 @@ const defaultVisibleSets = 6;
  *
  * @component
  * @param {CoreUpsetData | UpsetItem[]} data - The data for the Upset component.
- * @param {Partial<UpsetConfig>} [config={}] - The configuration options for the Upset component. This can be partial.
+ * @param {Partial<UpsetConfig>} [config={}] - The configuration options for the Upset component. This can be partial. Note that if extProvenance is also passed, the most recent state from extProvenance is used instead of this
  * @param {string[]} [visualizeAttributes] - List of attribute names (strings) which should be visualized. Defaults to the first 3 if no value is provided. If an empty list is provided, displays no attributes.
  * @param {boolean} [visualizeUpsetAttributes=false] - Whether or not to visualize UpSet generated attributes (`degree` and `deviation`). Defaults to `false`.
  * @param {boolean} [allowAttributeRemoval=false] - Whether or not to allow the user to remove attribute columns. This should be enabled only if there is an option within the parent application which allows for attributes to be added after removal. Default attribute removal behavior in UpSet 2.0 is done via context menu on attribute headers. Defaults to `false`.


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #381 
Closes #463 
Closes #460

### Give a longer description of what this PR addresses and why it's needed
- Fixes the default attribute plot not being set correctly
- Defaults attribute plots to density
- Fixes a bug where the bookmark star couldn't be used to unbookmark an intersection

## Detailed Copilot summary
This pull request includes several changes to the `packages/upset` components, focusing on improving type safety, fixing typos, and enhancing state management. The most important changes are summarized below:

### Type Safety Improvements:

* [`packages/upset/src/components/Columns/BookmarkStar.tsx`](diffhunk://#diff-a961b15b953da43db0dcb7e7712ddfa554fd348b7414cdbd9625fafbcd19be1fL37-R40): Added explicit type annotations to the `actions` object in the `ProvenanceContext` to ensure type safety.

### Code Cleanup and Refactoring:

* [`packages/upset/src/components/Columns/BookmarkStar.tsx`](diffhunk://#diff-a961b15b953da43db0dcb7e7712ddfa554fd348b7414cdbd9625fafbcd19be1fL82-R95): Refactored the `handleClick` function to create a `bookmark` object before using it in conditional logic.
* [`packages/upset/src/components/Root.tsx`](diffhunk://#diff-4c3ad80fec1c53b73efab777e900debe48b7d56c06b4f7b5192aaeaa8a600786L75-R92): Corrected the capitalization of the `setCanEditPlotInformation` function for consistency.

### State Management Enhancements:

* [`packages/upset/src/components/Root.tsx`](diffhunk://#diff-4c3ad80fec1c53b73efab777e900debe48b7d56c06b4f7b5192aaeaa8a600786L114-R126): Updated the `useEffect` hook to include mandatory state defaults for `attributePlots` to ensure proper initialization.
* [`packages/upset/src/components/Root.tsx`](diffhunk://#diff-4c3ad80fec1c53b73efab777e900debe48b7d56c06b4f7b5192aaeaa8a600786L125-R137): Modified the `useEffect` hook to include `allowAttributeRemoval` as a dependency, ensuring the state is updated correctly when this prop changes.

## Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed