### PR TITLE
Feb '25 Updates to Element View UX

### DIFF
--- a/e2e-tests/elementView.spec.ts
+++ b/e2e-tests/elementView.spec.ts
@@ -86,7 +86,7 @@ test('Element View', async ({ page, browserName }) => {
   await expect(ageCell).toBeVisible();
 
   // Check that the add plot button is visible
-  const addPlot = await page.locator('.MuiPaper-root > div:nth-child(2) > button').first();
+  const addPlot = await page.getByRole('button', { name: 'Add Plot' });
   await expect(addPlot).toBeVisible();
   await addPlot.click();
 
@@ -104,8 +104,7 @@ test('Element View', async ({ page, browserName }) => {
   const option2 = page.locator('div').filter({ hasText: /^BinsBins$/ }).first();
   await expect(option2).toBeVisible();
 
-  const option3 = await page.locator('label').filter({ hasText: 'Frequency' });
-  await expect(option3).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'KDE' })).toBeVisible();
 
   // close the plot preview
   const closeButton = await page.getByRole('heading', { name: 'Add Plot' }).getByRole('button');

--- a/e2e-tests/queryBySets.spec.ts
+++ b/e2e-tests/queryBySets.spec.ts
@@ -15,8 +15,8 @@ test('Query by Sets', async ({ page }) => {
   await page.locator('g:nth-child(2) > g > circle:nth-child(3)').click();
   await page.locator('g:nth-child(4) > g > circle:nth-child(4)').click();
 
-// TODO: Add a test for changing the name. As is, playwright struggles to handle web dialog inputs
-  
+  // TODO: Add a test for changing the name. As is, playwright struggles to handle web dialog inputs
+
   // Ensure that the text is correct
   await page.getByText('intersections of set [Evil]').click();
 
@@ -24,9 +24,8 @@ test('Query by Sets', async ({ page }) => {
   await page.getByLabel('Add query').locator('rect').click();
 
   // This specific query size is 5
-  await page.locator('text').filter({ hasText: /^5$/ }).click();
+  await expect(page.locator('text').filter({ hasText: /^5$/ })).toBeVisible();
 
   // Remove the query
   await page.getByLabel('Remove query').locator('rect').click();
-
 });

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -21,7 +21,7 @@ import { UpsetActions } from '../provenance';
 import { plotInformationSelector } from '../atoms/config/plotInformationAtom';
 import { canEditPlotInformationAtom } from '../atoms/config/canEditPlotInformationAtom';
 import { Sidebar } from './custom/Sidebar';
-import { UpsetHeading } from './custom/theme/Heading';
+import { UpsetHeading } from './custom/theme/heading';
 
 /**
  * Props for the AltTextSidebar component.

--- a/packages/upset/src/components/AltTextSidebar.tsx
+++ b/packages/upset/src/components/AltTextSidebar.tsx
@@ -21,7 +21,7 @@ import { UpsetActions } from '../provenance';
 import { plotInformationSelector } from '../atoms/config/plotInformationAtom';
 import { canEditPlotInformationAtom } from '../atoms/config/canEditPlotInformationAtom';
 import { Sidebar } from './custom/Sidebar';
-import { UpsetHeading } from './custom/theme/heading';
+import { UpsetHeading } from './custom/theme/Heading';
 
 /**
  * Props for the AltTextSidebar component.
@@ -157,10 +157,8 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
       close={close}
       closeButtonTabIndex={PLOT_INFO_TABS + PLOT_INFO_TAB_INDEX}
       label="Alt Text and Plot Information Sidebar"
+      title={displayPlotInfo ? plotInfo.title ?? 'Editing Plot Information' : 'Text Description'}
     >
-      <UpsetHeading level="h1">
-        {displayPlotInfo ? plotInfo.title ?? 'Editing Plot Information' : 'Text Description'}
-      </UpsetHeading>
       {displayPlotInfo &&
           // We only want to display plotInfo if the user is editing OR if they've entered some field other than title
           (plotInfoEditing || Object.entries(plotInfo).filter(([k, _]) => k !== 'title').some(([_, v]) => !!v)) ? (
@@ -181,7 +179,7 @@ export const AltTextSidebar: FC<Props> = ({ open, close, generateAltText }) => {
           ) : null
         )}
       {displayPlotInfo && (
-      <UpsetHeading level="h2" style={{ marginTop: '10px' }}>Text Description</UpsetHeading>
+      <UpsetHeading level="h2" divStyle={{ marginTop: '10px' }}>Text Description</UpsetHeading>
       )}
       {/* 0.875em for default 16px = 1em makes 14px, which is the standard for much of the UI */}
       <Box style={{ overflowY: 'auto', fontSize: '0.875em' }}>

--- a/packages/upset/src/components/ElementView/AddPlot.tsx
+++ b/packages/upset/src/components/ElementView/AddPlot.tsx
@@ -47,7 +47,7 @@ type ButtonProps = {
   /**
    * If type is histogram, whether to plot frequency (when true; binned) or density (when false; continuous)
    */
-  frequency?: boolean;
+  density?: boolean;
   /**
    * If type is scatterplot, the x attribute
    */
@@ -72,7 +72,7 @@ type ButtonProps = {
  * @returns Button
  */
 const AddButton: FC<ButtonProps> = ({
-  handleClose, type, bins, attribute, frequency, x, y, xScaleLog, yScaleLog, disabled,
+  handleClose, type, bins, attribute, density, x, y, xScaleLog, yScaleLog, disabled,
 }) => {
   const { actions } = useContext(ProvenanceContext);
 
@@ -95,7 +95,7 @@ const AddButton: FC<ButtonProps> = ({
           ...(type === 'Histogram' && {
             attribute,
             bins,
-            frequency,
+            frequency: density,
           }),
         });
         handleClose();
@@ -215,12 +215,11 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
  * UI for adding a histogram to the element view
  * @param param0 @see Props
  */
-export const AddHistogram: FC<Props> = ({ handleClose }) => {
+export const AddHistogram: FC<Props & {density: boolean}> = ({ handleClose, density }) => {
   const items = useRecoilValue(itemsAtom);
   const attributeColumns = useRecoilValue(dataAttributeSelector);
   const [attribute, setAttribute] = useState(attributeColumns[0]);
   const [bins, setBins] = useState(20);
-  const [frequency, setFrequency] = useState(true);
 
   return (
     <Grid container spacing={1} sx={{ width: '100%', height: '100%' }}>
@@ -243,9 +242,10 @@ export const AddHistogram: FC<Props> = ({ handleClose }) => {
         </FormControl>
       </Grid>
 
+      {!density &&
       <Grid container item xs={4}>
         <TextField
-          disabled={frequency}
+          disabled={density}
           label="Bins"
           value={bins}
           type="number"
@@ -255,19 +255,7 @@ export const AddHistogram: FC<Props> = ({ handleClose }) => {
             if (newBins > 0) setBins(newBins);
           }}
         />
-      </Grid>
-
-      <Grid container item xs={4}>
-        <FormControlLabel
-          label="Frequency"
-          control={
-            <Switch
-              value={frequency}
-              onChange={() => setFrequency(!frequency)}
-            />
-          }
-        />
-      </Grid>
+      </Grid>}
 
       <Grid container item xs={12}>
         {attribute && bins > 0 && Object.values(items).length && (
@@ -278,24 +266,24 @@ export const AddHistogram: FC<Props> = ({ handleClose }) => {
                 type: 'Histogram',
                 attribute,
                 bins,
-                frequency,
+                frequency: density,
               }}
               data={{
                 elements: Object.values(JSON.parse(JSON.stringify(items))),
               }}
             />
 
-      </Box>
-      )}
-      <AddButton
-        disabled={!(attribute && bins > 0 && Object.values(items).length)}
-        handleClose={handleClose}
-        type="Histogram"
-        attribute={attribute}
-        bins={bins}
-        frequency={frequency}
-      />
+          </Box>
+        )}
+        <AddButton
+          disabled={!(attribute && bins > 0 && Object.values(items).length)}
+          handleClose={handleClose}
+          type="Histogram"
+          attribute={attribute}
+          bins={bins}
+          density={density}
+        />
+      </Grid>
     </Grid>
-  </Grid>
   );
 };

--- a/packages/upset/src/components/ElementView/AddPlotDialog.tsx
+++ b/packages/upset/src/components/ElementView/AddPlotDialog.tsx
@@ -6,7 +6,7 @@ import { FC, ReactNode, useState } from 'react';
 
 import { AddHistogram, AddScatterplot } from './AddPlot';
 
-type PlotType = 'Scatterplot' | 'Histogram';
+type PlotType = 'Scatterplot' | 'Histogram' | 'KDE';
 
 type TabProps = {
   children?: ReactNode;
@@ -69,13 +69,17 @@ export const AddPlotDialog: FC<Props> = ({ open, onClose }) => {
       >
         <Tab label="Scatterplot" value="Scatterplot" />
         <Tab label="Histogram" value="Histogram" />
+        <Tab label="KDE" value="KDE" />
       </Tabs>
 
       <TabPanel index="Scatterplot" value={currentTab}>
         <AddScatterplot handleClose={onClose} />
       </TabPanel>
       <TabPanel index="Histogram" value={currentTab}>
-        <AddHistogram handleClose={onClose} />
+        <AddHistogram handleClose={onClose} density={false} />
+      </TabPanel>
+      <TabPanel index="KDE" value={currentTab}>
+        <AddHistogram handleClose={onClose} density />
       </TabPanel>
     </Dialog>
   );

--- a/packages/upset/src/components/ElementView/BookmarkChips.tsx
+++ b/packages/upset/src/components/ElementView/BookmarkChips.tsx
@@ -2,7 +2,7 @@ import SquareIcon from '@mui/icons-material/Square';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { Chip, Stack } from '@mui/material';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import {
@@ -52,15 +52,8 @@ export const BookmarkChips = () => {
     }
   }
 
-  /** Whether there is at least 1 chip */
-  const hasChip = useMemo(
-    () => currentIntersection || currentSelection || bookmarked.length > 0,
-    [currentIntersection, currentSelection, bookmarked],
-  );
-
   return (
-    // Silly goofy stack treats minHeight as maxHeight when we have chips... why??? idk
-    <Stack direction="row" sx={{ flexFlow: 'row wrap', minHeight: hasChip ? undefined : '40px' }}>
+    <Stack direction="row" sx={{ flexFlow: 'row wrap' }}>
       {/* All chips from bookmarks */}
       {bookmarked.map((bookmark) => (
         <Chip

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -19,7 +19,7 @@ import { ElementVisualization } from './ElementVisualization';
 import { QueryInterface } from './QueryInterface';
 import { bookmarkSelector, currentIntersectionSelector } from '../../atoms/config/currentIntersectionAtom';
 import { Sidebar } from '../custom/Sidebar';
-import { UpsetHeading } from '../custom/theme/Heading';
+import { UpsetHeading } from '../custom/theme/heading';
 import { AddPlotDialog } from './AddPlotDialog';
 
 /**

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -1,5 +1,6 @@
 import DownloadIcon from '@mui/icons-material/Download';
 import {
+  Alert,
   IconButton, Tooltip,
 } from '@mui/material';
 import { Item } from '@visdesignlab/upset2-core';
@@ -110,8 +111,13 @@ export const ElementSidebar = ({ open, close }: Props) => {
         </UpsetHeading>
       </div>
       <UpsetHeading level="h3">
-        {showQueries ? 'Selections' : 'Selections Will Appear Here'}
+        Selections
       </UpsetHeading>
+      {!showQueries && (
+        <Alert severity="info">
+          Selected intersections and elements will appear here.
+        </Alert>
+      )}
       <BookmarkChips />
       <ElementVisualization />
       <AddPlotDialog open={openAddPlot} onClose={onClose} />

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -19,7 +19,7 @@ import { ElementVisualization } from './ElementVisualization';
 import { QueryInterface } from './QueryInterface';
 import { bookmarkSelector, currentIntersectionSelector } from '../../atoms/config/currentIntersectionAtom';
 import { Sidebar } from '../custom/Sidebar';
-import { UpsetHeading } from '../custom/theme/heading';
+import { UpsetHeading } from '../custom/theme/Heading';
 import { AddPlotDialog } from './AddPlotDialog';
 
 /**
@@ -97,6 +97,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
       open={open}
       close={close}
       label="Element View Sidebar"
+      title="Element View"
       buttons={
         <Tooltip title="Add Plot">
           <IconButton onClick={() => setOpenAddPlot(true)}>
@@ -105,11 +106,6 @@ export const ElementSidebar = ({ open, close }: Props) => {
         </Tooltip>
       }
     >
-      <div style={{ marginBottom: '1em' }}>
-        <UpsetHeading level="h1">
-          Element View
-        </UpsetHeading>
-      </div>
       <UpsetHeading level="h3">
         Selections
       </UpsetHeading>
@@ -121,11 +117,11 @@ export const ElementSidebar = ({ open, close }: Props) => {
       <BookmarkChips />
       <ElementVisualization />
       <AddPlotDialog open={openAddPlot} onClose={onClose} />
-      <UpsetHeading level="h2" style={{ marginTop: '1em' }}>
+      <UpsetHeading level="h2" divStyle={{ marginTop: '1em' }}>
         Element Queries
       </UpsetHeading>
       <QueryInterface />
-      <UpsetHeading level="h2" style={{ marginTop: '1em' }}>
+      <UpsetHeading level="h2" divStyle={{ marginTop: '1em' }}>
         Query Result
         <Tooltip title={`Download ${itemCount} elements`}>
           <IconButton

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -110,7 +110,7 @@ export const ElementSidebar = ({ open, close }: Props) => {
         Selections
       </UpsetHeading>
       {!showQueries && (
-        <Alert severity="info">
+        <Alert severity="info" style={{ paddingTop: '2px', paddingBottom: '2px' }}>
           Selected intersections and elements will appear here.
         </Alert>
       )}

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -51,6 +51,7 @@ export const ElementTable: FC = () => {
   const elements = useRecoilValue(selectedItemsSelector);
   const rows = useRows(elements);
   const setColumns = useRecoilValue(setColumnsSelector);
+  // Filtering out columns w/ _ removes metadata columns
   const columns = useColumns(['_label', ...([...attributeColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
 
   return (

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -30,11 +30,17 @@ function useRows(items: Item[]): GridRowsProp {
  * @returns array of columns with item field to be displayed in the DataGrid and headerName
  */
 function useColumns(columns: string[]) {
-  return useMemo(() => columns.map((col) => ({
-    field: col,
+  const setColumns = useRecoilValue(setColumnsSelector);
+  return useMemo(() => columns.map((col) => {
     // Prefixed with _ since that's how the Item object is structured
-    headerName: col === '_id' ? 'ID' : col === '_label' ? 'Label' : col,
-  })), [columns]);
+    const displayName = col === '_id' ? 'ID' : col === '_label' ? 'Label' : col;
+    return {
+      field: col,
+      headerName: displayName,
+      type: setColumns.includes(col) ? 'boolean' : 'string',
+      description: displayName,
+    };
+  }), [columns]);
 }
 
 /**
@@ -45,12 +51,7 @@ export const ElementTable: FC = () => {
   const elements = useRecoilValue(selectedItemsSelector);
   const rows = useRows(elements);
   const setColumns = useRecoilValue(setColumnsSelector);
-  let columns = useColumns(['_label', ...([...attributeColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
-  // Add a boolean type to set columns so they display properly
-  columns = columns.map((col) => ({
-    ...col,
-    type: setColumns.includes(col.field) ? 'boolean' : 'string',
-  }));
+  const columns = useColumns(['_label', ...([...attributeColumns, ...setColumns].filter((col) => !col.startsWith('_')))]);
 
   return (
     <Box

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -131,7 +131,7 @@ export const ElementVisualization = () => {
       >
         {(plots.length > 0) && specs.map(({ plot, spec }) => (
           // Relative position is necessary so this serves as a positioning container for the close button
-          <Box style={{ display: 'inline-block', position: 'relative' }}>
+          <Box style={{ display: 'inline-block', position: 'relative' }} key={plot.id}>
             <IconButton
               style={{
                 position: 'absolute', top: 0, right: -15, zIndex: 100, padding: 0,

--- a/packages/upset/src/components/ElementView/generatePlotSpec.ts
+++ b/packages/upset/src/components/ElementView/generatePlotSpec.ts
@@ -209,7 +209,7 @@ export function generateHistogramSpec(
     scale: { range: { field: 'color' } },
   };
 
-  if (hist.density) {
+  if (hist.frequency) {
     return {
       width: 200,
       height: 200,

--- a/packages/upset/src/components/ElementView/generatePlotSpec.ts
+++ b/packages/upset/src/components/ElementView/generatePlotSpec.ts
@@ -133,15 +133,15 @@ export function generateScatterplotSpec(
  * Creates the spec for a single histogram, used in the "Add Plot" dialog.
  * @param attribute The attribute to plot.
  * @param bins      The number of bins to use.
- * @param frequency Whether to plot frequency or density; true for frequency.
+ * @param density Whether to plot frequency or density; true for frequency.
  * @returns The Vega-Lite spec for the histogram.
  */
 export function createAddHistogramSpec(
   attribute: string,
   bins: number,
-  frequency: boolean,
+  density: boolean,
 ): VisualizationSpec {
-  if (frequency) {
+  if (density) {
     const base: VisualizationSpec = {
       width: 400,
       height: 400,
@@ -209,7 +209,7 @@ export function generateHistogramSpec(
     scale: { range: { field: 'color' } },
   };
 
-  if (hist.frequency) {
+  if (hist.density) {
     return {
       width: 200,
       height: 200,

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -3,7 +3,7 @@ import {
 } from 'react';
 import { ProvVis } from '@trrack/vis-react';
 import { ProvenanceContext } from './Root';
-import { UpsetHeading } from './custom/theme/heading';
+import { UpsetHeading } from './custom/theme/Heading';
 import { Sidebar } from './custom/Sidebar';
 
 type Props = {

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -3,7 +3,6 @@ import {
 } from 'react';
 import { ProvVis } from '@trrack/vis-react';
 import { ProvenanceContext } from './Root';
-import { UpsetHeading } from './custom/theme/heading';
 import { Sidebar } from './custom/Sidebar';
 
 type Props = {
@@ -42,10 +41,8 @@ export const ProvenanceVis = ({ open, close }: Props) => {
       open={open}
       close={close}
       label="History Sidebar"
+      title="History"
     >
-      <UpsetHeading level="h1">
-        History
-      </UpsetHeading>
       {provVis}
     </Sidebar>
   );

--- a/packages/upset/src/components/ProvenanceVis.tsx
+++ b/packages/upset/src/components/ProvenanceVis.tsx
@@ -3,7 +3,7 @@ import {
 } from 'react';
 import { ProvVis } from '@trrack/vis-react';
 import { ProvenanceContext } from './Root';
-import { UpsetHeading } from './custom/theme/Heading';
+import { UpsetHeading } from './custom/theme/heading';
 import { Sidebar } from './custom/Sidebar';
 
 type Props = {

--- a/packages/upset/src/components/SettingsSidebar.tsx
+++ b/packages/upset/src/components/SettingsSidebar.tsx
@@ -55,7 +55,7 @@ import { UpsetActions } from '../provenance';
 import { attributeAtom } from '../atoms/attributeAtom';
 import { visibleAttributesSelector } from '../atoms/config/visibleAttributes';
 import { showHiddenSetsSelector, showIntersectionSizesSelector, showSetSizesSelector } from '../atoms/config/displayAtoms';
-import { UpsetHeading } from './custom/theme/Heading';
+import { UpsetHeading } from './custom/theme/heading';
 
 const ITEM_DIV_CSS = css`
   display: flex;

--- a/packages/upset/src/components/SettingsSidebar.tsx
+++ b/packages/upset/src/components/SettingsSidebar.tsx
@@ -55,7 +55,7 @@ import { UpsetActions } from '../provenance';
 import { attributeAtom } from '../atoms/attributeAtom';
 import { visibleAttributesSelector } from '../atoms/config/visibleAttributes';
 import { showHiddenSetsSelector, showIntersectionSizesSelector, showSetSizesSelector } from '../atoms/config/displayAtoms';
-import { UpsetHeading } from './custom/theme/heading';
+import { UpsetHeading } from './custom/theme/Heading';
 
 const ITEM_DIV_CSS = css`
   display: flex;

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -2,13 +2,14 @@ import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import CloseFullscreen from '@mui/icons-material/CloseFullscreen';
 import CloseIcon from '@mui/icons-material/Close';
 import {
-  Box, Drawer, IconButton, Tooltip,
+  Box, Divider, Drawer, IconButton, Tooltip,
 } from '@mui/material';
 import React, {
   FC, PropsWithChildren, useCallback, useState,
 } from 'react';
 import { useRecoilValue } from 'recoil';
 import { footerHeightAtom } from '../../atoms/dimensionsAtom';
+import { UpsetHeading } from './theme/Heading';
 
 type Props= {
   /** Whether the sidebar is open */
@@ -19,6 +20,8 @@ type Props= {
   closeButtonTabIndex?: number;
   /** Aria-label for the sidebar */
   label: string;
+  /** Title for the sidebar, to be displayed at the top */
+  title: string;
   /** Buttons to display at the top of the sidebar, left of the close & expand */
   buttons?: React.ReactNode;
 }
@@ -30,7 +33,7 @@ const BUTTON_DIMS = { height: '40px', width: '40px' };
  * A collapsible, right-sidebar for the plot
  */
 export const Sidebar: FC<PropsWithChildren<Props>> = ({
-  open, close, closeButtonTabIndex, children, label, buttons,
+  open, close, closeButtonTabIndex, children, label, title, buttons,
 }) => {
   /** Chosen so we don't get a horizontal scrollbar in the element view table */
   const INITIAL_DRAWER_WIDTH = 462;
@@ -115,51 +118,69 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
         }}
         onMouseDown={(e) => handleMouseDown(e)}
       />
-      <div style={{
-        display: 'flex', justifyContent: 'end', position: 'absolute', top: '20px', right: 0,
-      }}
-      >
-        {buttons}
-        { !fullWidth ?
-          <Tooltip title="Expand to full screen">
-            <IconButton
-              style={BUTTON_DIMS} // Necessary so that the shadow remains square even when we change the font size
-              onClick={() => {
-                setFullWidth(true);
-              }}
-              aria-label="Expand the sidebar in full screen"
-            >
-              {/* CRAZY, I know. 1 font size px changes the icon SVG dimensions (square) by .75px. So this is
+      <Box display="flex" flexWrap="nowrap" flexDirection="row" marginBottom="1em">
+        <div style={{
+          minWidth: 0, alignSelf: 'center', flexGrow: 1, flexShrink: 1, width: '100%', display: 'flex', alignItems: 'center',
+        }}
+        >
+          <UpsetHeading
+            level="h1"
+            hideDivider
+            divStyle={{ marginBottom: 0, width: '100%' }}
+            headingStyle={{
+              marginBottom: 0, whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden', width: '100%',
+            }}
+          >
+            {title}
+          </UpsetHeading>
+        </div>
+        <div style={{
+          display: 'flex', justifyContent: 'end', flexGrow: 0, flexShrink: 0, alignSelf: 'end',
+        }}
+        >
+          {buttons}
+          { !fullWidth ?
+            <Tooltip title="Expand to full screen">
+              <IconButton
+                style={BUTTON_DIMS} // Necessary so that the shadow remains square even when we change the font size
+                onClick={() => {
+                  setFullWidth(true);
+                }}
+                aria-label="Expand the sidebar in full screen"
+              >
+                {/* CRAZY, I know. 1 font size px changes the icon SVG dimensions (square) by .75px. So this is
             EXACTLY the font size needed to get this icon SVG to be the same dimensions as the close button: 14x14 */}
-              <OpenInFullIcon style={{ fontSize: '18.67px' }} />
+                <OpenInFullIcon style={{ fontSize: '18.67px' }} />
+              </IconButton>
+            </Tooltip>
+            :
+            <Tooltip title="Reduce to normal size">
+              <IconButton
+                style={BUTTON_DIMS} // Not actually necessary (it's 40*40 by default) but it's here for consistency
+                onClick={() => {
+                  if (fullWidth) {
+                    setFullWidth(false);
+                  }
+                }}
+                aria-label="Reduce the sidebar to normal size"
+              >
+                <CloseFullscreen />
+              </IconButton>
+            </Tooltip>}
+          <Tooltip title="Close">
+            <IconButton
+              onClick={() => {
+                close();
+              }}
+              tabIndex={closeButtonTabIndex}
+              aria-label="Close the sidebar"
+            >
+              <CloseIcon />
             </IconButton>
           </Tooltip>
-          :
-          <Tooltip title="Reduce to normal size">
-            <IconButton
-              style={BUTTON_DIMS} // Not actually necessary (it's 40*40 by default) but it's here for consistency
-              onClick={() => {
-                if (fullWidth) {
-                  setFullWidth(false);
-                }
-              }}
-              aria-label="Reduce the sidebar to normal size"
-            >
-              <CloseFullscreen />
-            </IconButton>
-          </Tooltip>}
-        <Tooltip title="Close">
-          <IconButton
-            onClick={() => {
-              close();
-            }}
-            tabIndex={closeButtonTabIndex}
-            aria-label="Close the sidebar"
-          >
-            <CloseIcon />
-          </IconButton>
-        </Tooltip>
-      </div>
+        </div>
+      </Box>
+      <Divider style={{ width: '100%', margin: '0 auto' }} aria-hidden />
       {children}
       <Box minHeight={footerHeight} />
     </Drawer>

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import { useRecoilValue } from 'recoil';
 import { footerHeightAtom } from '../../atoms/dimensionsAtom';
-import { UpsetHeading } from './theme/Heading';
+import { UpsetHeading } from './theme/heading';
 
 type Props= {
   /** Whether the sidebar is open */

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -102,6 +102,11 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
       variant="persistent"
       anchor="right"
       aria-label={label}
+      // This disables the slide in-out animation
+      // If you want all sidebars to have the slide animation, remove this; but you also will
+      // need to change the rendering of ElementSidebar so that it's always rendered, not just
+      // when elementSidebar.open (in Root.tsx 190)
+      transitionDuration={0}
     >
       <Box
         sx={{

--- a/packages/upset/src/components/custom/Sidebar.tsx
+++ b/packages/upset/src/components/custom/Sidebar.tsx
@@ -123,7 +123,7 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
         }}
         onMouseDown={(e) => handleMouseDown(e)}
       />
-      <Box display="flex" flexWrap="nowrap" flexDirection="row" marginBottom="1em">
+      <Box display="flex" flexWrap="nowrap" flexDirection="row">
         <div style={{
           minWidth: 0, alignSelf: 'center', flexGrow: 1, flexShrink: 1, width: '100%', display: 'flex', alignItems: 'center',
         }}
@@ -185,7 +185,7 @@ export const Sidebar: FC<PropsWithChildren<Props>> = ({
           </Tooltip>
         </div>
       </Box>
-      <Divider style={{ width: '100%', margin: '0 auto' }} aria-hidden />
+      <Divider style={{ width: '100%', margin: '0 auto', marginBottom: '1em' }} aria-hidden />
       {children}
       <Box minHeight={footerHeight} />
     </Drawer>

--- a/packages/upset/src/components/custom/theme/heading.tsx
+++ b/packages/upset/src/components/custom/theme/heading.tsx
@@ -16,7 +16,11 @@ type Props = {
   /** Left padding for the typography */
   paddingLeft?: string;
   /** CSS for the wrapper div */
-  style?: CSSProperties;
+  divStyle?: CSSProperties;
+  /** CSS for the h element */
+  headingStyle?: CSSProperties;
+  /** Whether to hide the divider at the bottom */
+  hideDivider?: boolean;
 }
 
 /**
@@ -33,26 +37,24 @@ const LEVELS: {[level in HeadingLevel]: { fontSize: string; }} = {
  * A heading for use in the UI; keeps styles consistent
  */
 export const UpsetHeading: FC<PropsWithChildren<Props>> = ({
-  level, paddingLeft, style, children,
+  level, paddingLeft, divStyle, headingStyle, children, hideDivider = false,
 }) => {
   const IS_MAJOR = level === 'h1' || level === 'h2' || level === 'h3';
 
   return (
-    <div style={{ marginBottom: '.5em', ...style }}>
+    <div style={{ marginBottom: '.5em', ...divStyle }}>
       <Typography
         variant={level}
         fontSize={LEVELS[level].fontSize}
         fontWeight="inherit"
         gutterBottom={level === 'h1'}
         paddingLeft={paddingLeft}
+        style={{ ...headingStyle }}
       >
         {children}
       </Typography>
-      {IS_MAJOR && <Divider
-        style={{
-          width: '100%',
-          margin: '0 auto',
-        }}
+      {IS_MAJOR && !hideDivider && <Divider
+        style={{ width: '100%', margin: '0 auto' }}
         aria-hidden
       />}
     </div>

--- a/packages/upset/src/dimensions.ts
+++ b/packages/upset/src/dimensions.ts
@@ -86,16 +86,15 @@ export function calculateDimensions(
 
   const header = {
     totalWidth:
-      set.label.height + // Label Height === Label Width
-      set.width * nVisibleSets + // Offset for total sets
-      gap + // Add margin
-      size.width + // Size
+      matrixColumn.width + // Matrix Column
       bookmarkStar.gap +
       bookmarkStar.width + // Bookmark Star
       bookmarkStar.gap +
+      size.width + // Size
+      gap + // Gap for size labels
       (degree ? degreeColumn.width + // Degree Column
       degreeColumn.gap : 0) + // Add margin
-      (attribute.vGap + attribute.width) * nAttributes, // Show all attributes
+      (attribute.width + attribute.vGap) * nAttributes, // Attributes
     totalHeight: set.size.height + set.label.height,
   };
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #489 
Closes #484 
Closes #485 
Closes #487 
Closes #464 
Closes #449 

### Give a longer description of what this PR addresses and why it's needed
- Adds a tooltip for the column headers in the element view table showing the full name of the column
- Adds an alert (selections will appear here) when no bookmark chips are present; this alert takes up the same height as one bookmark chip
- Adds a 3rd tab to the Add Plot dialog for KDE plots, replacing the previous checkbox
- Shortens sidebar titles with an ellipsis when they overflow
- Further corrects the plot width calculation to remove extra width on the right side
- Removes all sidebar open/close animations

### Copilot auto-generated summary
This pull request includes changes to improve the user interface and functionality of the `ElementView` component, specifically focusing on the `AltTextSidebar`, `AddPlot`, and `Sidebar` components. The most important changes include updating the titles and headings, modifying the histogram plotting functionality, and enhancing the sidebar layout.

Improvements to titles and headings:

* [`packages/upset/src/components/AltTextSidebar.tsx`](diffhunk://#diff-8c8e2d7462508d1c6d70582e1f2239557ee3d20c42d789fca873b9351e9a0f56R160-L163): Updated the title and removed redundant `UpsetHeading` elements. [[1]](diffhunk://#diff-8c8e2d7462508d1c6d70582e1f2239557ee3d20c42d789fca873b9351e9a0f56R160-L163) [[2]](diffhunk://#diff-8c8e2d7462508d1c6d70582e1f2239557ee3d20c42d789fca873b9351e9a0f56L184-R182)
* [`packages/upset/src/components/ElementView/ElementSidebar.tsx`](diffhunk://#diff-81030da6f2b4f5cfb05f2e98619e4ec88dce4f8cdba522e216db8c2a57b19b7bR100): Added a title to the sidebar and replaced `UpsetHeading` elements with a new title format. [[1]](diffhunk://#diff-81030da6f2b4f5cfb05f2e98619e4ec88dce4f8cdba522e216db8c2a57b19b7bR100) [[2]](diffhunk://#diff-81030da6f2b4f5cfb05f2e98619e4ec88dce4f8cdba522e216db8c2a57b19b7bL107-R124)
* [`packages/upset/src/components/ProvenanceVis.tsx`](diffhunk://#diff-87a9cfd2e851bf747d6c68ee3dd60ffb1de0817fe0be0825a95260c0e153beb5R44-L48): Added a title to the history sidebar and removed the `UpsetHeading` element.

Modifications to histogram plotting:

* [`packages/upset/src/components/ElementView/AddPlot.tsx`](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L50-R50): Replaced the `frequency` prop with `density` for histogram plots and updated the related logic. [[1]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L50-R50) [[2]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L75-R75) [[3]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L98-R98) [[4]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L218-L223) [[5]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873R245-R248) [[6]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L258-R258) [[7]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L281-R269) [[8]](diffhunk://#diff-d96edd7a6469eb7383b1577a0aef5a2fe6366fbd7f5b20d0a0ebe725e5259873L296-R284)
* [`packages/upset/src/components/ElementView/generatePlotSpec.ts`](diffhunk://#diff-10abdb3800a956142fcdd2f230164fe66dbc4e163329c5d9517ad4576e2d6fb2L136-R144): Updated the histogram spec generation functions to use `density` instead of `frequency`. [[1]](diffhunk://#diff-10abdb3800a956142fcdd2f230164fe66dbc4e163329c5d9517ad4576e2d6fb2L136-R144) [[2]](diffhunk://#diff-10abdb3800a956142fcdd2f230164fe66dbc4e163329c5d9517ad4576e2d6fb2L212-R212)

Enhancements to sidebar layout:

* [`packages/upset/src/components/custom/Sidebar.tsx`](diffhunk://#diff-c306f0cf2d35a097e744791de48bb3089e1f8ad7cff9b9ef375a0c432903b3fcR23-R24): Added a title prop to the sidebar component and adjusted the layout to include the title at the top. [[1]](diffhunk://#diff-c306f0cf2d35a097e744791de48bb3089e1f8ad7cff9b9ef375a0c432903b3fcR23-R24) [[2]](diffhunk://#diff-c306f0cf2d35a097e744791de48bb3089e1f8ad7cff9b9ef375a0c432903b3fcL33-R36) [[3]](diffhunk://#diff-c306f0cf2d35a097e744791de48bb3089e1f8ad7cff9b9ef375a0c432903b3fcR105-R109) [[4]](diffhunk://#diff-c306f0cf2d35a097e744791de48bb3089e1f8ad7cff9b9ef375a0c432903b3fcR126-R143)
* [`packages/upset/src/components/ElementView/BookmarkChips.tsx`](diffhunk://#diff-3399777e5234647bfaa421236bc3fbd10e8679bc5d348242f7cde494d4c6e088L55-R56): Simplified the layout by removing unnecessary `useMemo` usage.

Other changes:

* [`packages/upset/src/components/ElementView/AddPlotDialog.tsx`](diffhunk://#diff-e106e3799a56aa9ce903f11911bb5a4438fc016f47b7a7b0457b9cc239a25613L9-R9): Added a new tab for KDE plots in the `AddPlotDialog` component. [[1]](diffhunk://#diff-e106e3799a56aa9ce903f11911bb5a4438fc016f47b7a7b0457b9cc239a25613L9-R9) [[2]](diffhunk://#diff-e106e3799a56aa9ce903f11911bb5a4438fc016f47b7a7b0457b9cc239a25613R72-R82)
* [`packages/upset/src/components/ElementView/ElementTable.tsx`](diffhunk://#diff-27dbffe7130775eeac6303c869c3c27659de85585320a215a6a097b69e2c93d8L33-R43): Refactored the column generation logic to include display names and types. [[1]](diffhunk://#diff-27dbffe7130775eeac6303c869c3c27659de85585320a215a6a097b69e2c93d8L33-R43) [[2]](diffhunk://#diff-27dbffe7130775eeac6303c869c3c27659de85585320a215a6a097b69e2c93d8L48-R54)
* [`packages/upset/src/components/ElementView/ElementVisualization.tsx`](diffhunk://#diff-6c88c3280d337a578578419461e724eb60bdb60f58c2f08aa5ee41e23fa7aff9L134-R134): Added a key prop to the plot `Box` component to ensure unique identification.
