### PR TITLE
Size scaling fixes

### DIFF
--- a/packages/upset/src/atoms/setQuerySizeSelector.ts
+++ b/packages/upset/src/atoms/setQuerySizeSelector.ts
@@ -1,0 +1,14 @@
+import { selector } from 'recoil';
+import { flattenedRowsSelector } from './renderRowsAtom';
+
+export const setQuerySizeSelector = selector<number>({
+  key: 'setQuerySizeSelector',
+  get: ({ get }) => {
+    const rows = get(flattenedRowsSelector);
+    let total = 0;
+    rows.forEach((rr) => {
+      total += rr.row.size;
+    });
+    return total;
+  },
+});

--- a/packages/upset/src/atoms/setQuerySizeSelector.ts
+++ b/packages/upset/src/atoms/setQuerySizeSelector.ts
@@ -1,6 +1,11 @@
 import { selector } from 'recoil';
 import { flattenedRowsSelector } from './renderRowsAtom';
 
+/**
+ * Selector to calculate the total size of all rows present within a set query.
+ *
+ * @returns {number} The total size of all rows in the set query.
+ */
 export const setQuerySizeSelector = selector<number>({
   key: 'setQuerySizeSelector',
   get: ({ get }) => {

--- a/packages/upset/src/components/Columns/SizeBar.tsx
+++ b/packages/upset/src/components/Columns/SizeBar.tsx
@@ -109,6 +109,7 @@ export const SizeBar: FC<Props> = ({ row, size, selected }) => {
     return colors[index];
   }, [row, selected, bookmarks, bookmarkedColorPallete, currentIntersection, nextColor]);
 
+
   /**
    * Calculates the number of size bars to display based on the size of the row.
    * @param rowSize Size of the row.
@@ -123,7 +124,9 @@ export const SizeBar: FC<Props> = ({ row, size, selected }) => {
     if (fullBars >= 3) {
       fullBars = 3;
     }
-    if (rem === 0 && fullBars > 0) fullBars--;
+
+    // If the remainder is 0 and there are 1 or 2 full bars, remove a bar
+    if (rem === 0 && (fullBars > 0 && fullBars < 3)) fullBars--;
 
     return { fullBars, rem };
   }, [sizeDomain]);

--- a/packages/upset/src/components/Header/SizeHeader.tsx
+++ b/packages/upset/src/components/Header/SizeHeader.tsx
@@ -18,6 +18,9 @@ import { ProvenanceContext } from '../Root';
 import { contextMenuAtom } from '../../atoms/contextMenuAtom';
 import { HeaderSortArrow } from '../custom/HeaderSortArrow';
 import { flattenedRowsSelector } from '../../atoms/renderRowsAtom';
+import { setQueryAtom } from '../../atoms/config/queryBySetsAtoms';
+import { setQuerySizeSelector } from '../../atoms/setQuerySizeSelector';
+import { isPopulatedSetQuery } from '@visdesignlab/upset2-core';
 
 const hide = css`
   opacity: 0;
@@ -39,6 +42,8 @@ export const SizeHeader: FC = () => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const items = useRecoilValue(itemsAtom);
   const subsets = useRecoilValue(flattenedRowsSelector).map((r) => r.row);
+  const setQuery = useRecoilValue(setQueryAtom);
+  const setQuerySize = useRecoilValue(setQuerySizeSelector);
   const sortBy = useRecoilValue(sortBySelector);
   const sortByOrder = useRecoilValue(sortByOrderSelector);
 
@@ -113,10 +118,18 @@ export const SizeHeader: FC = () => {
   useEffect(() => {
     if (advancedScale || subsets.length === 0) return;
 
+    // If a set query is present, use the set query size
+    // This is necessary because the setQuery is not a ROW so is not caught in subsets
+    if (isPopulatedSetQuery(setQuery)) {
+      setMaxSize(setQuerySize);
+      return;
+    }
+
     const sizes = subsets.map((s) => s.size);
+
     const maxS = Math.max(...sizes);
     setMaxSize(maxS);
-  }, [subsets, maxSize, advancedScale]);
+  }, [subsets, maxSize, advancedScale, setQuery]);
 
   const globalScale = useScale([0, itemCount], [0, dimensions.attribute.width]);
   const detailScale = useScale([0, maxC], [0, dimensions.attribute.width]);

--- a/packages/upset/src/components/Header/SizeHeader.tsx
+++ b/packages/upset/src/components/Header/SizeHeader.tsx
@@ -154,8 +154,8 @@ export const SizeHeader: FC = () => {
 
         const size = globalScale.invert(newPosition);
 
-        // Gets the minimum size scale to 0.5% of the total number of items or 5, whichever is smaller
-        const minSize = Math.min(...[0.005 * itemCount, 5]);
+        // Gets the minimum size scale to 0.5% of the total number of items (min of 1) or 5, whichever is smaller
+        const minSize = Math.ceil(Math.min(...[0.005 * itemCount, 5]));
 
         // If the new position is at the very left of the slider (0), set the max size to the minimum size
         if (newPosition === 0) {

--- a/packages/upset/src/components/custom/QueryBySet/SetQueryRow.tsx
+++ b/packages/upset/src/components/custom/QueryBySet/SetQueryRow.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useMemo } from 'react';
+import { FC, useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { SetMembershipStatus } from '@visdesignlab/upset2-core';
@@ -12,8 +12,8 @@ import MemberShipCircle from '../../Columns/Matrix/MembershipCircle';
 import { setQueryAtom } from '../../../atoms/config/queryBySetsAtoms';
 import { ProvenanceContext } from '../../Root';
 import { SizeBar } from '../../Columns/SizeBar';
-import { flattenedRowsSelector } from '../../../atoms/renderRowsAtom';
 import { DEFAULT_ROW_BACKGROUND_COLOR, DEFAULT_ROW_BACKGROUND_OPACITY, ROW_BORDER_STROKE_COLOR, ROW_BORDER_STROKE_WIDTH } from '../../../utils/styles';
+import { setQuerySizeSelector } from '../../../atoms/setQuerySizeSelector';
 
 const REMOVE_ICON_SIZE = 16;
 
@@ -32,7 +32,7 @@ export const SetQueryRow: FC = () => {
   const dimensions = useRecoilValue(dimensionsSelector);
   const visibleSets = useRecoilValue(visibleSetSelector);
   const setQuery = useRecoilValue(setQueryAtom);
-  const rows = useRecoilValue(flattenedRowsSelector);
+  const setQuerySize = useRecoilValue(setQuerySizeSelector);
 
   /**
    * Retrieves the membership status for a given set from the set query sets.
@@ -51,19 +51,6 @@ export const SetQueryRow: FC = () => {
   function removeSetQuery(): void {
     actions.removeSetQuery();
   }
-
-  /**
-   * Calculates the total size of all rows in the query.
-   *
-   * @returns {number} The total size of all rows.
-   */
-  const totalQuerySize = useMemo(() => {
-    let total = 0;
-    rows.forEach((rr) => {
-      total += rr.row.size;
-    });
-    return total;
-  }, [rows]);
 
   return (
     <g transform={translate(0, 0)}>
@@ -122,7 +109,7 @@ export const SetQueryRow: FC = () => {
             ))}
           </g>
           <g transform={translate(0, dimensions.body.rowHeight - 2)}>
-            <SizeBar size={totalQuerySize} selected={0} />
+            <SizeBar size={setQuerySize} selected={0} />
           </g>
         </g>
       </g>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #497 
Closes #486 

### Give a longer description of what this PR addresses and why it's needed
This PR addresses the size bar scaling for the set query rows as well as the minimum size scale.
Previously, the advanced scale minimum was 10% of the total items, which was not necessarily useful. This is especially noticeable when there are no subsets that are near the max size. See previous behavior gif below.

Now, the size scale minimum is set to EITHER 0.05% of the total items (with a minimum of 1) or 5, whichever is smaller. This means that for a small dataset (Simpsons), the minimum is 1, whereas for a large dataset (movies), the minimum is 5. For movies, the 0.05% value is something like 16, so for smaller subsets, this value is simply too large.

### Provide pictures/videos of the behavior before and after these changes (optional)
BEFORE:
![upset-sizescale-prev](https://github.com/user-attachments/assets/5124a0cc-e701-4c3a-95c1-126707b01806)

movies - 
![upset-sizescale-prev-movies](https://github.com/user-attachments/assets/fce08cfb-674e-4390-a0b2-02ef96acd3a4)


AFTER:
![upset-sizescale-after](https://github.com/user-attachments/assets/9e683d79-9a38-4b58-9fbc-570f6b710a8c)

movies - 
![upset-sizescale-after-movies](https://github.com/user-attachments/assets/3b9afe90-6e24-48f8-bb12-ca0b98224ad5)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [X] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- None
