### PR TITLE
Add column hover state clear when vega selection is made

### DIFF
--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -18,6 +18,7 @@ import { ProvenanceContext } from '../Root';
 import { UpsetActions } from '../../provenance';
 import { contextMenuAtom } from '../../atoms/contextMenuAtom';
 import { currentSelectionType, currentVegaSelection } from '../../atoms/config/selectionAtoms';
+import { columnSelectAtom } from '../../atoms/highlightAtom';
 
 const BRUSH_NAME = 'brush';
 
@@ -62,6 +63,7 @@ export const ElementVisualization = () => {
   const selectionType = useRecoilValue(currentSelectionType);
   const { actions }: {actions: UpsetActions} = useContext(ProvenanceContext);
   const setContextMenu = useSetRecoilState(contextMenuAtom);
+  const setColumnSelection = useSetRecoilState(columnSelectAtom);
 
   /**
    * Internal State
@@ -107,6 +109,10 @@ export const ElementVisualization = () => {
       && !vegaSelectionsEqual(draftSelection.current, selection ?? undefined)
     ) {
       actions.setVegaSelection(draftSelection.current);
+
+      // reset the column selection highlight state because the selection has changed
+      setColumnSelection([]);
+
       if (selectionType !== 'vega') actions.setSelectionType('vega');
     } else if (selection) {
       actions.setVegaSelection(null);

--- a/packages/upset/src/components/ElementView/QueryInterface.tsx
+++ b/packages/upset/src/components/ElementView/QueryInterface.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
 } from '@mui/material';
 import { Box } from '@mui/system';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { ElementQueryType, NumericalQueryType } from '@visdesignlab/upset2-core';
 import {
   useCallback, useContext, useEffect, useState,
@@ -14,6 +14,7 @@ import { ProvenanceContext } from '../Root';
 import { UpsetActions } from '../../provenance';
 import { attTypesSelector } from '../../atoms/attributeAtom';
 import { currentSelectionType, currentQuerySelection } from '../../atoms/config/selectionAtoms';
+import { columnSelectAtom } from '../../atoms/highlightAtom';
 
 /**
  * Default type for the element query
@@ -34,6 +35,7 @@ export const QueryInterface = () => {
   const selectionType = useRecoilValue(currentSelectionType);
   const { actions }: { actions: UpsetActions } = useContext(ProvenanceContext);
   const attTypes = useRecoilValue(attTypesSelector);
+  const setColSelection = useSetRecoilState(columnSelectAtom);
 
   const FIELD_MARGIN = '5px';
   const FIELD_CSS = { marginTop: FIELD_MARGIN, width: '50%' };
@@ -53,7 +55,7 @@ export const QueryInterface = () => {
       setTypeField(DEFAULT_TYPE);
       setQueryField(undefined);
     }
-  }, [currentSelection]);
+  }, [currentSelection, atts]);
 
   /*
    * Functions
@@ -79,8 +81,9 @@ export const QueryInterface = () => {
         query: queryField,
       });
       actions.setSelectionType('query');
+      setColSelection([]);
     }
-  }, [attField, typeField, queryField, atts, actions, currentSelection, selectionType]);
+  }, [attField, typeField, queryField, atts, actions, currentSelection, selectionType, setColSelection]);
 
   return atts.length > 0 ? (
     <Box css={{ marginTop: '10px' }}>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #533 

### Give a longer description of what this PR addresses and why it's needed
This removes the column hover state when a Vega selection is made. Previously the column hover would be maintained despite there being no selection.

### Provide pictures/videos of the behavior before and after these changes (optional)

#### Before
![column-highlight-before](https://github.com/user-attachments/assets/1952a5c4-55d8-4483-8388-0272e6f13d45)

#### After
![column-highlight-after](https://github.com/user-attachments/assets/1faadf02-b0a7-4c5d-8452-462a9b2902bf)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
None
