### PR TITLE
Eslint and type fixes

### DIFF
--- a/e2e-tests/queryBySets.spec.ts
+++ b/e2e-tests/queryBySets.spec.ts
@@ -4,7 +4,9 @@ import { beforeTest } from './common';
 test.beforeEach(beforeTest);
 
 test('Query by Sets', async ({ page }) => {
-  await page.goto('http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193');
+  await page.goto(
+    'http://localhost:3000/?workspace=Upset+Examples&table=simpsons&sessionId=193',
+  );
 
   // open Query by sets interface
   await page.getByTestId('AddIcon').locator('path').click();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,6 +59,15 @@ export default defineConfig([
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      // needs to be duplicated because we have this rule in 2 plugins (=
+      'no-unused-vars': [
+        'warn', // or "error"
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
       'max-len': 'off',
       'no-param-reassign': 'off',
       'import/no-cycle': 'off',

--- a/packages/app/src/api/generateAltText.ts
+++ b/packages/app/src/api/generateAltText.ts
@@ -1,14 +1,27 @@
-import { AltText, isAltText, UpsetConfig } from '@visdesignlab/upset2-core';
+import { AltText, isAltText, isObject, UpsetConfig } from '@visdesignlab/upset2-core';
 import { api } from './api';
+
+/**
+ * The actual type returned by the API
+ * @private May be changed by MultiNet in the future
+ */
+export type AltTextResponse = {
+  alttxt: AltText;
+};
 
 /**
  * Generates alternative text based on the provided configuration.
  * @param {UpsetConfig}config - The configuration object for generating alternative text.
  * @returns A promise that resolves to the generated alternative text.
  */
-export async function generateAltText(config: UpsetConfig): Promise<AltText> {
+export async function generateAltText(config: UpsetConfig): Promise<AltTextResponse> {
   const response = await api.generateAltText(true, config);
-  if (!isAltText(response.alttxt))
-    console.error('Invalid alt text received from API:', response.alttxt);
-  return response.alttxt;
+  if (
+    !isObject(response) ||
+    !Object.hasOwn(response, 'alttxt') ||
+    // @ts-expect-error We've checked that this prop exists
+    !isAltText(response.alttxt)
+  )
+    console.error('Invalid alt text received from API:', response);
+  return response;
 }

--- a/packages/app/src/api/generateAltText.ts
+++ b/packages/app/src/api/generateAltText.ts
@@ -1,4 +1,4 @@
-import { UpsetConfig } from '@visdesignlab/upset2-core';
+import { AltText, isAltText, UpsetConfig } from '@visdesignlab/upset2-core';
 import { api } from './api';
 
 /**
@@ -6,6 +6,9 @@ import { api } from './api';
  * @param {UpsetConfig}config - The configuration object for generating alternative text.
  * @returns A promise that resolves to the generated alternative text.
  */
-export async function generateAltText(config: UpsetConfig): Promise<any> {
-  return api.generateAltText(true, config);
+export async function generateAltText(config: UpsetConfig): Promise<AltText> {
+  const response = await api.generateAltText(true, config);
+  if (!isAltText(response.alttxt))
+    console.error('Invalid alt text received from API:', response.alttxt);
+  return response.alttxt;
 }

--- a/packages/app/src/api/getUserInfo.ts
+++ b/packages/app/src/api/getUserInfo.ts
@@ -9,6 +9,7 @@ export const getUserInfo = async () => {
   try {
     const info = await api.userInfo();
     return info;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     if (e.response && e.response.status === 401) {
       return null;

--- a/packages/app/src/atoms/selectors.ts
+++ b/packages/app/src/atoms/selectors.ts
@@ -34,7 +34,7 @@ export const attributeValuesCount = selectorFamily<number, string>({
   get:
     (att: string) =>
     ({ get }) =>
-      Object.values(get(itemsSelector)).filter((item) => !!item[att]).length,
+      Object.values(get(itemsSelector)).filter((item) => !!item.atts[att]).length,
 });
 
 /**

--- a/packages/app/src/components/Body.tsx
+++ b/packages/app/src/components/Body.tsx
@@ -1,5 +1,5 @@
-import { AltText, Upset, getAltTextConfig } from '@visdesignlab/upset2-react';
-import { CoreUpsetData, deepCopy, UpsetConfig } from '@visdesignlab/upset2-core';
+import { Upset, getAltTextConfig } from '@visdesignlab/upset2-react';
+import { AltText, CoreUpsetData, deepCopy, UpsetConfig } from '@visdesignlab/upset2-core';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { Backdrop, CircularProgress } from '@mui/material';
@@ -117,6 +117,7 @@ export const Body = ({ data, config }: Props) => {
     let response;
     try {
       response = await generateAltText(ATConfig);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       if (e.response.status === 500) {
         throw Error(

--- a/packages/app/src/components/DataTable.tsx
+++ b/packages/app/src/components/DataTable.tsx
@@ -48,7 +48,8 @@ const setColumns: GridColDef[] = [
 
 /**
  * Data for a row in the data table.
- * @private to show up correctly in the DataGrid component, this must be a flat
+ * @private to show up correctly in the DataGrid component, this must be a flat array; we unfortunately cannot
+ *   put attributes in a nested object.
  */
 type RowData = {
   id: string;

--- a/packages/app/src/components/ErrorModal.tsx
+++ b/packages/app/src/components/ErrorModal.tsx
@@ -11,7 +11,6 @@ import {
   MenuItem,
   OutlinedInput,
   Select,
-  SelectChangeEvent,
   Button,
 } from '@mui/material';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -45,7 +44,7 @@ export const ErrorModal = () => {
     needOneHot = true;
   }
 
-  const handleChange = (e: SelectChangeEvent) => {
+  const handleChange = (e: { target: { value: string[] | string } }) => {
     const {
       target: { value },
     } = e;
@@ -83,13 +82,13 @@ export const ErrorModal = () => {
                   labelId="multiple-checkbox-label"
                   id="multiple-checkbox"
                   multiple
-                  value={encodeList as any}
+                  value={encodeList}
                   onChange={handleChange}
                   input={<OutlinedInput label="Columns to encode" />}
-                  renderValue={(selected: any) => selected.join(', ')}
+                  renderValue={(selected) => selected.join(', ')}
                   MenuProps={MenuProps}
                 >
-                  {Object.entries(data.columnTypes).map(([name, type]) => (
+                  {Object.entries(data.columnTypes).map(([name]) => (
                     <MenuItem key={name} value={name}>
                       <Checkbox checked={encodeList.includes(name)} />
                       <ListItemText primary={name} />

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -92,7 +92,7 @@ const Header = ({ data }: { data: CoreUpsetData }) => {
     setIsMenuOpen(false);
   };
 
-  const handleLoginOpen = (event: React.MouseEvent<any>) => {
+  const handleLoginOpen = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setAnchorEl(event.currentTarget);
     setLoginMenuOpen(true);
   };

--- a/packages/app/src/components/ImportModal.tsx
+++ b/packages/app/src/components/ImportModal.tsx
@@ -19,7 +19,7 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
   const { actions, provenance } = useContext(ProvenanceContext);
   const setImportError = useSetRecoilState(importErrorAtom);
 
-  const isMissingFields = (newState: any) => {
+  function isMissingFields(newState: Record<string, never>): boolean {
     const state = provenance.getState();
     let isMissing = false;
 
@@ -31,7 +31,7 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
     });
 
     return isMissing;
-  };
+  }
 
   async function readFile(file: File) {
     const data = await file.text();
@@ -39,7 +39,7 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
     let newState;
     try {
       newState = JSON.parse(data);
-    } catch (e) {
+    } catch {
       throw new Error('Invalid File Upload. Please upload a .json UpSet state file.');
     }
     const state = provenance.getState();
@@ -70,8 +70,7 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
               'state-upload-file',
             ) as HTMLInputElement;
 
-            input !== null &&
-              input.files !== null &&
+            if (input !== null && input.files !== null)
               readFile(input.files[0]).catch((e) => {
                 setIsError({
                   isOpen: true,

--- a/packages/app/src/components/ImportModal.tsx
+++ b/packages/app/src/components/ImportModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -18,6 +18,7 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
   });
   const { actions, provenance } = useContext(ProvenanceContext);
   const setImportError = useSetRecoilState(importErrorAtom);
+  const fileInput = useRef<HTMLInputElement>(null);
 
   function isMissingFields(newState: Record<string, never>): boolean {
     const state = provenance.getState();
@@ -60,18 +61,14 @@ export const ImportModal = (props: { open: boolean; close: () => void }) => {
     <Dialog open={props.open} onClose={props.close}>
       <DialogTitle>Upload Upset State (.json)</DialogTitle>
       <DialogContent>
-        <input type="file" id="state-upload-file" />
+        <input type="file" id="state-upload-file" ref={fileInput} />
         <Button
           variant="contained"
           size="small"
           aria-errormessage="import-error"
           onClick={() => {
-            const input: HTMLInputElement | null = document.getElementById(
-              'state-upload-file',
-            ) as HTMLInputElement;
-
-            if (input !== null && input.files !== null)
-              readFile(input.files[0]).catch((e) => {
+            if (fileInput.current !== null && fileInput.current.files !== null)
+              readFile(fileInput.current.files[0]).catch((e) => {
                 setIsError({
                   isOpen: true,
                   message: e.message,

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -68,7 +68,12 @@ oAuth.maybeRestoreLogin().then(() => {
     invalidateSharedLoginCookie();
   }
 
-  const container = document.getElementById('root') as HTMLElement;
+  const container = document.getElementById('root');
+  if (!container) {
+    console.error('Root container not found');
+    return;
+  }
+
   const root = createRoot(container);
   root.render(
     <React.StrictMode>

--- a/packages/app/src/utils/oneHotEncoding.ts
+++ b/packages/app/src/utils/oneHotEncoding.ts
@@ -17,7 +17,7 @@ export const oneHotEncode = (
   //    ex: group1_a, group1_b, group2_a, group2_b, group3_c, ....
   encodeList.forEach((s) =>
     Object.entries(data.items).forEach(([_, row]) => {
-      const names = `${row[s]}`
+      const names = `${row.atts[s]}`
         .split(',')
         .filter((n) => n !== '')
         .map((val) => `${s}_${val}`);
@@ -30,7 +30,7 @@ export const oneHotEncode = (
   Object.entries(encodedData.items).forEach(([_, row]) => {
     Array.from(uniqueColNames).forEach((col) => {
       const splitCol = col.split('_');
-      row[col] = `${row[splitCol[0]]}`.includes(splitCol[1]);
+      row.atts[col] = `${row.atts[splitCol[0]]}`.includes(splitCol[1]);
     });
   });
 
@@ -43,7 +43,12 @@ export const oneHotEncode = (
 
   // Casting as the columnTypes will always be 'boolean', so
   return process(
-    Object.values(encodedData.items).map((item) => ({ _key: '', _rev: '', ...item })),
+    Object.values(encodedData.items).map((item) => ({
+      _key: '',
+      _rev: '',
+      _id: '',
+      ...item.atts,
+    })),
     annotations,
   );
 };

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -28,14 +28,14 @@ import {
  * @param row - The row object from which to retrieve the items.
  * @returns An array of unique items from the row.
  */
-export function getItems(row: Row) {
+export function getItems(row: Row): string[] {
   if (isRowSubset(row)) {
-    return row.items;
+    return row.items ?? [];
   }
   const items: string[] = [];
 
-  row.items.order.forEach((subsetId) => {
-    const element = row.items.values[subsetId];
+  row.rows.order.forEach((subsetId) => {
+    const element = row.rows.values[subsetId];
 
     items.push(...getItems(element));
   });
@@ -71,7 +71,7 @@ export const getAggSize = (row: Row) => {
   }
   let size = 0;
 
-  Object.values(row.items.values).forEach((r) => {
+  Object.values(row.rows.values).forEach((r) => {
     size += getAggSize(r);
   });
 
@@ -111,7 +111,7 @@ function aggregateByDegree(
     const agg: Aggregate = {
       id,
       elementName: `Degree ${i}`,
-      items: {
+      rows: {
         values: {},
         order: [],
       },
@@ -143,8 +143,8 @@ function aggregateByDegree(
 
     subset = { ...subset, parent: relevantAggregate.id };
 
-    relevantAggregate.items.values[subsetId] = subset;
-    relevantAggregate.items.order.push(subsetId);
+    relevantAggregate.rows.values[subsetId] = subset;
+    relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
     relevantAggregate.attributes.deviation += subset.attributes.deviation;
   });
@@ -200,7 +200,7 @@ function aggregateBySets(
     const agg: Aggregate = {
       id,
       elementName,
-      items: {
+      rows: {
         values: {},
         order: [],
       },
@@ -237,8 +237,8 @@ function aggregateBySets(
 
       subset = { ...subset, parent: relevantAggregate.id };
 
-      relevantAggregate.items.values[subsetId] = subset;
-      relevantAggregate.items.order.push(subsetId);
+      relevantAggregate.rows.values[subsetId] = subset;
+      relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
       relevantAggregate.attributes.deviation += subset.attributes.deviation;
     }
@@ -248,8 +248,8 @@ function aggregateBySets(
 
       subset = { ...subset, parent: relevantAggregate.id };
 
-      relevantAggregate.items.values[subsetId] = subset;
-      relevantAggregate.items.order.push(subsetId);
+      relevantAggregate.rows.values[subsetId] = subset;
+      relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
       relevantAggregate.attributes.deviation += subset.attributes.deviation;
     });
@@ -305,7 +305,7 @@ function aggregateByDeviation(
       id,
       elementName,
       description,
-      items: {
+      rows: {
         values: {},
         order: [],
       },
@@ -336,8 +336,8 @@ function aggregateByDeviation(
 
     subset = { ...subset, parent: relevantAggregate.id };
 
-    relevantAggregate.items.values[subsetId] = subset;
-    relevantAggregate.items.order.push(subsetId);
+    relevantAggregate.rows.values[subsetId] = subset;
+    relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
     relevantAggregate.attributes.deviation += subset.attributes.deviation;
   });
@@ -402,7 +402,7 @@ function aggregateByOverlaps(
     const agg: Aggregate = {
       id,
       elementName,
-      items: {
+      rows: {
         values: {},
         order: [],
       },
@@ -438,8 +438,8 @@ function aggregateByOverlaps(
 
       subset = { ...subset, parent: relevantAggregate.id };
 
-      relevantAggregate.items.values[subsetId] = subset;
-      relevantAggregate.items.order.push(subsetId);
+      relevantAggregate.rows.values[subsetId] = subset;
+      relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
       relevantAggregate.attributes.deviation += subset.attributes.deviation;
     });
@@ -548,9 +548,9 @@ export function secondAggregation(
 
   aggregates.order.forEach((aggId: string) => {
     const agg = aggregates.values[aggId];
-    if (areRowsSubsets(agg.items)) {
+    if (areRowsSubsets(agg.rows)) {
       const itms = aggregateSubsets(
-        agg.items,
+        agg.rows,
         aggregateBy,
         overlapDegree,
         sets,

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -51,9 +51,9 @@ export function getItems(row: Row): string[] {
  */
 function updateAggValues(aggs: Aggregates, items: Items, attributeColumns: string[]) {
   aggs.order.forEach((aggId) => {
-    aggs.values[aggId].attributes = {
+    aggs.values[aggId].atts = {
       ...getSixNumberSummary(items, getItems(aggs.values[aggId]), attributeColumns),
-      deviation: aggs.values[aggId].attributes.deviation,
+      deviation: aggs.values[aggId].atts.deviation,
     };
   });
 }
@@ -121,7 +121,7 @@ function aggregateByDegree(
       aggregateBy: 'Degree',
       level,
       description: i === 0 ? 'in no set' : `${i} set intersection`,
-      attributes: {
+      atts: {
         deviation: 0,
       },
     };
@@ -146,7 +146,7 @@ function aggregateByDegree(
     relevantAggregate.rows.values[subsetId] = subset;
     relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
-    relevantAggregate.attributes.deviation += subset.attributes.deviation;
+    relevantAggregate.atts.deviation += subset.atts.deviation;
   });
 
   updateAggValues(aggs, items, attributeColumns);
@@ -213,7 +213,7 @@ function aggregateBySets(
       aggregateBy: 'Sets',
       level,
       description: elementName,
-      attributes: {
+      atts: {
         deviation: 0,
       },
     };
@@ -240,7 +240,7 @@ function aggregateBySets(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.attributes.deviation += subset.attributes.deviation;
+      relevantAggregate.atts.deviation += subset.atts.deviation;
     }
 
     belongingSets.forEach((set) => {
@@ -251,7 +251,7 @@ function aggregateBySets(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.attributes.deviation += subset.attributes.deviation;
+      relevantAggregate.atts.deviation += subset.atts.deviation;
     });
   });
 
@@ -314,7 +314,7 @@ function aggregateByDeviation(
       setMembership: {},
       aggregateBy: 'Deviations',
       level,
-      attributes: {
+      atts: {
         deviation: 0,
       },
     };
@@ -330,7 +330,7 @@ function aggregateByDeviation(
 
   subsets.order.forEach((subsetId) => {
     let subset = subsets.values[subsetId];
-    const deviationType = subset.attributes.deviation >= 0 ? 'pos' : 'neg';
+    const deviationType = subset.atts.deviation >= 0 ? 'pos' : 'neg';
 
     const relevantAggregate = aggs.values[deviationMap[deviationType]];
 
@@ -339,7 +339,7 @@ function aggregateByDeviation(
     relevantAggregate.rows.values[subsetId] = subset;
     relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
-    relevantAggregate.attributes.deviation += subset.attributes.deviation;
+    relevantAggregate.atts.deviation += subset.atts.deviation;
   });
 
   updateAggValues(aggs, items, attributeColumns);
@@ -412,7 +412,7 @@ function aggregateByOverlaps(
       setMembership: sm,
       level,
       description: setNames.join(' - '),
-      attributes: {
+      atts: {
         deviation: 0,
       },
     };
@@ -441,7 +441,7 @@ function aggregateByOverlaps(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.attributes.deviation += subset.attributes.deviation;
+      relevantAggregate.atts.deviation += subset.atts.deviation;
     });
   });
 

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -52,8 +52,10 @@ export function getItems(row: Row): string[] {
 function updateAggValues(aggs: Aggregates, items: Items, attributeColumns: string[]) {
   aggs.order.forEach((aggId) => {
     aggs.values[aggId].atts = {
-      ...getSixNumberSummary(items, getItems(aggs.values[aggId]), attributeColumns),
-      deviation: aggs.values[aggId].atts.deviation,
+      dataset: {
+        ...getSixNumberSummary(items, getItems(aggs.values[aggId]), attributeColumns),
+      },
+      derived: { deviation: aggs.values[aggId].atts.derived.deviation },
     };
   });
 }
@@ -122,7 +124,8 @@ function aggregateByDegree(
       level,
       description: i === 0 ? 'in no set' : `${i} set intersection`,
       atts: {
-        deviation: 0,
+        dataset: {},
+        derived: { deviation: 0 },
       },
     };
 
@@ -146,7 +149,7 @@ function aggregateByDegree(
     relevantAggregate.rows.values[subsetId] = subset;
     relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
-    relevantAggregate.atts.deviation += subset.atts.deviation;
+    relevantAggregate.atts.derived.deviation += subset.atts.derived.deviation;
   });
 
   updateAggValues(aggs, items, attributeColumns);
@@ -214,7 +217,8 @@ function aggregateBySets(
       level,
       description: elementName,
       atts: {
-        deviation: 0,
+        dataset: {},
+        derived: { deviation: 0 },
       },
     };
 
@@ -240,7 +244,7 @@ function aggregateBySets(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.atts.deviation += subset.atts.deviation;
+      relevantAggregate.atts.derived.deviation += subset.atts.derived.deviation;
     }
 
     belongingSets.forEach((set) => {
@@ -251,7 +255,7 @@ function aggregateBySets(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.atts.deviation += subset.atts.deviation;
+      relevantAggregate.atts.derived.deviation += subset.atts.derived.deviation;
     });
   });
 
@@ -315,7 +319,8 @@ function aggregateByDeviation(
       aggregateBy: 'Deviations',
       level,
       atts: {
-        deviation: 0,
+        dataset: {},
+        derived: { deviation: 0 },
       },
     };
 
@@ -330,7 +335,7 @@ function aggregateByDeviation(
 
   subsets.order.forEach((subsetId) => {
     let subset = subsets.values[subsetId];
-    const deviationType = subset.atts.deviation >= 0 ? 'pos' : 'neg';
+    const deviationType = subset.atts.derived.deviation >= 0 ? 'pos' : 'neg';
 
     const relevantAggregate = aggs.values[deviationMap[deviationType]];
 
@@ -339,7 +344,7 @@ function aggregateByDeviation(
     relevantAggregate.rows.values[subsetId] = subset;
     relevantAggregate.rows.order.push(subsetId);
     relevantAggregate.size += subset.size;
-    relevantAggregate.atts.deviation += subset.atts.deviation;
+    relevantAggregate.atts.derived.deviation += subset.atts.derived.deviation;
   });
 
   updateAggValues(aggs, items, attributeColumns);
@@ -413,7 +418,8 @@ function aggregateByOverlaps(
       level,
       description: setNames.join(' - '),
       atts: {
-        deviation: 0,
+        dataset: {},
+        derived: { deviation: 0 },
       },
     };
 
@@ -441,7 +447,7 @@ function aggregateByOverlaps(
       relevantAggregate.rows.values[subsetId] = subset;
       relevantAggregate.rows.order.push(subsetId);
       relevantAggregate.size += subset.size;
-      relevantAggregate.atts.deviation += subset.atts.deviation;
+      relevantAggregate.atts.derived.deviation += subset.atts.derived.deviation;
     });
   });
 

--- a/packages/core/src/combinations.ts
+++ b/packages/core/src/combinations.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-param-reassign */
-/* eslint-disable no-shadow */
 /**
  * Generates all combinations of length 'n' from an array of elements.
  *
@@ -8,22 +6,21 @@
  * @param {number} n - The length of combinations to generate.
  * @returns {T[][]} - An array of combinations of length 'n'.
  */
-export function combinationsFromArray<T>(collection: T[], n: number) {
+export function combinationsFromArray<T>(collection: T[], n: number): T[][] {
   const array: T[] = Object.values(collection);
   if (array.length < n) {
     return [];
   }
   const recur = (array: T[], n: number) => {
-    // eslint-disable-next-line no-plusplus
     if (--n < 0) {
       return [[]];
     }
     const combinations: T[][] = [];
     array = array.slice();
     while (array.length - n) {
-      const value = array.shift() as T;
+      const value = array.shift();
       recur(array, n).forEach((combination) => {
-        combination.unshift(value);
+        if (value) combination.unshift(value);
         combinations.push(combination);
       });
     }

--- a/packages/core/src/convertConfig.ts
+++ b/packages/core/src/convertConfig.ts
@@ -1,3 +1,5 @@
+// Disabled as using any cast is useful for converting and there's no point hard typechecking these fields
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   AggregateBy,
   Bookmark,

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -224,9 +224,9 @@ function getSets(
       type: 'Set',
       size: setMembership[col].length,
       setMembership: { ...setMembershipStatus, [col]: 'Yes' },
-      attributes: {
-        ...getSixNumberSummary(items, setMembership[col], attributeColumns),
-        deviation: 0,
+      atts: {
+        dataset: getSixNumberSummary(items, setMembership[col], attributeColumns),
+        derived: { deviation: 0 },
       },
     };
 
@@ -340,11 +340,6 @@ export function getSubsets(
       setMembershipStatus[set] = combo[idx];
     });
 
-    const subsetAttributes = {
-      ...getSixNumberSummary(dataItems, itm, attributeColumns),
-      deviation: subsetDeviation,
-    };
-
     const subset: Subset = {
       id: getId('Subset', intersectionName[comboBinary]),
       elementName: intersectionName[comboBinary],
@@ -352,7 +347,10 @@ export function getSubsets(
       size: itm.length,
       type: 'Subset',
       setMembership: setMembershipStatus,
-      attributes: subsetAttributes,
+      atts: {
+        derived: { deviation: subsetDeviation },
+        dataset: getSixNumberSummary(dataItems, itm, attributeColumns),
+      },
     };
 
     subsets.values[subset.id] = subset;

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -125,24 +125,29 @@ function processRawData(data: TableRow[], columns: ColumnTypes) {
     const id = row['_id'] ? row['_id'] : getId('Item', idx.toString());
 
     const item: Item = {
-      _label: labelColumn === 'id' ? id : (row[labelColumn] as string),
-      ...row,
+      _label: labelColumn === 'id' ? id : row[labelColumn].toString(),
       _id: id, // This needs to be down here so it overwrites the _id from the row object
+      atts: row,
     };
     items[id] = item;
 
     Object.entries(columns).forEach(([col, type]) => {
-      if (type === 'number') {
-        item[col] = parseFloat(item[col] as any);
+      if (type === 'number' && typeof item.atts[col] === 'string') {
+        item.atts[col] = parseFloat(item.atts[col]);
       }
 
       if (type === 'boolean') {
-        const val = item[col];
-        item[col] = typeof val === 'boolean' ? +val : parseInt(val as any, 10);
+        const val = item.atts[col];
+        item.atts[col] =
+          typeof val === 'boolean'
+            ? +val
+            : typeof val === 'string'
+              ? parseInt(val, 10)
+              : val;
 
         if (!setMembership[col]) setMembership[col] = [];
 
-        if (item[col] === 1) setMembership[col].push(item['_id']);
+        if (item.atts[col] === 1) setMembership[col].push(item['_id']);
       }
     });
   });
@@ -157,12 +162,12 @@ function processRawData(data: TableRow[], columns: ColumnTypes) {
 }
 
 /**
- * Calculates the five-number summary for each attribute in the given items.
+ * Calculates the six-number summary for each attribute in the given items.
  *
  * @param items - The items to calculate the summary for.
  * @param memberItems - The member items to consider.
  * @param attributeColumns - The attribute columns to calculate the summary for.
- * @returns An object containing the five-number summary for each attribute.
+ * @returns An object containing the six-number summary for each attribute.
  */
 export function getSixNumberSummary(
   items: Items,
@@ -173,7 +178,7 @@ export function getSixNumberSummary(
 
   attributeColumns.forEach((attribute) => {
     const values = memberItems
-      .map((d) => items[d][attribute] as number)
+      .map((d) => items[d].atts[attribute] as number)
       .filter((val) => !Number.isNaN(val));
 
     attributes[attribute] = {
@@ -299,9 +304,9 @@ export function getSubsets(
   items.forEach((item) => {
     const itemMembership = vSetNames
       .map((v) =>
-        (typeof item[v] === 'number' && !Number.isNaN(item[v])) ||
-        typeof item[v] === 'boolean'
-          ? item[v]
+        (typeof item.atts[v] === 'number' && !Number.isNaN(item.atts[v])) ||
+        typeof item.atts[v] === 'boolean'
+          ? item.atts[v]
           : 0,
       )
       .join('');

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -154,9 +154,7 @@ const sortByRR = (data: CoreUpsetData, state: UpsetConfig, ignoreQuery = false) 
     return { order: [], values: {} };
 
   const vSets: Sets = Object.fromEntries(
-    Object.entries(data.sets as Sets).filter(([name]) =>
-      state.visibleSets.includes(name),
-    ),
+    Object.entries(data.sets).filter(([name]) => state.visibleSets.includes(name)),
   );
 
   let renderRows: Rows;

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -48,7 +48,7 @@ export const flattenRows = (
       row,
     });
     if (isRowAggregate(row)) {
-      flattenRows(row.items, flattenedRows, prefix);
+      flattenRows(row.rows, flattenedRows, prefix);
     }
   });
 

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -262,11 +262,11 @@ export function sortRows(
   ) as any;
 
   aggs.order.forEach((aggId) => {
-    const { items } = aggs.values[aggId];
+    const { rows: items } = aggs.values[aggId];
 
     const newItems = sortRows(items, sortBy, vSetSortBy, visibleSets, sortByOrder);
 
-    aggs.values[aggId].items = newItems;
+    aggs.values[aggId].rows = newItems;
   });
 
   return aggs;

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -105,8 +105,8 @@ function sortByDegree(
 function sortByDeviation(rows: Intersections, sortByOrder?: SortByOrder) {
   const { values, order } = rows;
   order.sort((a, b) => {
-    const devA = values[a].attributes.deviation;
-    const devB = values[b].attributes.deviation;
+    const devA = values[a].atts.deviation;
+    const devB = values[b].atts.deviation;
     return sortByOrder === 'Ascending' ? devA - devB : devB - devA;
   });
 
@@ -179,8 +179,8 @@ function sortByAttribute(rows: Intersections, sortBy: string, sortByOrder?: Sort
   const { values, order } = rows;
 
   order.sort((a, b) => {
-    const meanA = (values[a].attributes[sortBy] as SixNumberSummary).mean;
-    const meanB = (values[b].attributes[sortBy] as SixNumberSummary).mean;
+    const meanA = (values[a].atts[sortBy] as SixNumberSummary).mean;
+    const meanB = (values[b].atts[sortBy] as SixNumberSummary).mean;
 
     // If one of the values is undefined (empty subset), sort it to the bottom
     if (!meanA) {

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -1,16 +1,16 @@
 import {
   Intersections,
-  Aggregates,
   Rows,
   SortVisibleBy,
   Sets,
   SortByOrder,
-  SixNumberSummary,
+  BaseIntersection,
 } from './types';
 import {
   areRowsSubsets,
   getBelongingSetsFromSetMembership,
   getDegreeFromSetMembership,
+  isRowAggregate,
 } from './typeutils';
 import { deepCopy } from './utils';
 
@@ -41,7 +41,12 @@ function sortBySize(rows: Intersections, sortOrder?: SortByOrder) {
  * @param {SortVisibleBy} vSetSortBy - The sort order for visible sets.
  * @returns A number indicating the comparison result.
  */
-function compareUnionSizes(a: any, b: any, visibleSets: Sets, vSetSortBy: SortVisibleBy) {
+function compareUnionSizes(
+  a: BaseIntersection,
+  b: BaseIntersection,
+  visibleSets: Sets,
+  vSetSortBy: SortVisibleBy,
+) {
   const aUnionSize = Object.entries(a.setMembership)
     .filter(([_key, value]) => value === 'Yes')
     .map(([key, _value]) => visibleSets[key].size)
@@ -105,8 +110,8 @@ function sortByDegree(
 function sortByDeviation(rows: Intersections, sortByOrder?: SortByOrder) {
   const { values, order } = rows;
   order.sort((a, b) => {
-    const devA = values[a].atts.deviation;
-    const devB = values[b].atts.deviation;
+    const devA = values[a].atts.derived.deviation;
+    const devB = values[b].atts.derived.deviation;
     return sortByOrder === 'Ascending' ? devA - devB : devB - devA;
   });
 
@@ -179,8 +184,22 @@ function sortByAttribute(rows: Intersections, sortBy: string, sortByOrder?: Sort
   const { values, order } = rows;
 
   order.sort((a, b) => {
-    const meanA = (values[a].atts[sortBy] as SixNumberSummary).mean;
-    const meanB = (values[b].atts[sortBy] as SixNumberSummary).mean;
+    let meanA: number | undefined = 0;
+    let meanB: number | undefined = 0;
+    if (sortBy === 'Degree') {
+      meanA =
+        values[a].atts.derived.degree ??
+        getDegreeFromSetMembership(values[a].setMembership);
+      meanB =
+        values[b].atts.derived.degree ??
+        getDegreeFromSetMembership(values[b].setMembership);
+    } else if (sortBy === 'Deviation') {
+      meanA = values[a].atts.derived.deviation;
+      meanB = values[b].atts.derived.deviation;
+    } else {
+      meanA = values[a].atts.dataset[sortBy].mean;
+      meanB = values[b].atts.dataset[sortBy].mean;
+    }
 
     // If one of the values is undefined (empty subset), sort it to the bottom
     if (!meanA) {
@@ -253,20 +272,14 @@ export function sortRows(
     return sortIntersections(rows, sortBy, vSetSortBy, visibleSets, sortByOrder);
   }
 
-  const aggs: Aggregates = sortIntersections(
-    rows as any,
-    sortBy,
-    vSetSortBy,
-    visibleSets,
-    sortByOrder,
-  ) as any;
-
+  const aggs = sortIntersections(rows, sortBy, vSetSortBy, visibleSets, sortByOrder);
   aggs.order.forEach((aggId) => {
-    const { rows: items } = aggs.values[aggId];
+    const agg = aggs.values[aggId];
+    if (!isRowAggregate(agg)) return;
+    const { rows } = agg;
+    const newItems = sortRows(rows, sortBy, vSetSortBy, visibleSets, sortByOrder);
 
-    const newItems = sortRows(items, sortBy, vSetSortBy, visibleSets, sortByOrder);
-
-    aggs.values[aggId].rows = newItems;
+    agg.rows = newItems;
   });
 
   return aggs;

--- a/packages/core/src/typecheck.ts
+++ b/packages/core/src/typecheck.ts
@@ -24,6 +24,7 @@ import {
   SetQuery,
   SetMembershipStatus,
   TableRow,
+  Item,
 } from './types';
 import { deepCopy } from './utils';
 
@@ -59,7 +60,7 @@ export function isRowType(t: unknown): t is RowType {
  * @param r variable to check
  * @returns {boolean}
  */
-export function isBaseElement(r: unknown): r is BaseRow {
+export function isBaseRow(r: unknown): r is BaseRow {
   return (
     isObject(r) &&
     Object.hasOwn(r, 'id') &&
@@ -67,14 +68,14 @@ export function isBaseElement(r: unknown): r is BaseRow {
     Object.hasOwn(r, 'size') &&
     Object.hasOwn(r, 'type') &&
     Object.hasOwn(r, 'attributes') &&
-    Object.hasOwn(r, 'items') &&
     typeof (r as BaseRow).id === 'string' &&
     typeof (r as BaseRow).elementName === 'string' &&
     typeof (r as BaseRow).size === 'number' &&
     typeof (r as BaseRow).attributes === 'object' &&
     isRowType((r as BaseRow).type) &&
-    Array.isArray((r as BaseRow).items) &&
-    (r as BaseRow).items.every((i: unknown) => typeof i === 'string')
+    (!Object.hasOwn(r, 'items') ||
+      (Array.isArray((r as { items: Item[] }).items) &&
+        (r as { items: Item[] }).items.every((i: unknown) => typeof i === 'string')))
   );
 }
 
@@ -86,7 +87,7 @@ export function isBaseElement(r: unknown): r is BaseRow {
 export function isBaseIntersection(i: unknown): i is BaseIntersection {
   return (
     !!i &&
-    isBaseElement(i) &&
+    isBaseRow(i) &&
     Object.hasOwn(i, 'setMembership') &&
     typeof (i as BaseIntersection).setMembership === 'object' &&
     Object.values((i as BaseIntersection).setMembership).every(

--- a/packages/core/src/typecheck.ts
+++ b/packages/core/src/typecheck.ts
@@ -71,7 +71,7 @@ export function isBaseRow(r: unknown): r is BaseRow {
     typeof (r as BaseRow).id === 'string' &&
     typeof (r as BaseRow).elementName === 'string' &&
     typeof (r as BaseRow).size === 'number' &&
-    typeof (r as BaseRow).attributes === 'object' &&
+    typeof (r as BaseRow).atts === 'object' &&
     isRowType((r as BaseRow).type) &&
     (!Object.hasOwn(r, 'items') ||
       (Array.isArray((r as { items: Item[] }).items) &&

--- a/packages/core/src/typecheck.ts
+++ b/packages/core/src/typecheck.ts
@@ -5,7 +5,7 @@ import {
   AltText,
   AttributePlots,
   AttributePlotType,
-  BaseElement,
+  BaseRow,
   BaseIntersection,
   Bookmark,
   Column,
@@ -59,7 +59,7 @@ export function isRowType(t: unknown): t is RowType {
  * @param r variable to check
  * @returns {boolean}
  */
-export function isBaseElement(r: unknown): r is BaseElement {
+export function isBaseElement(r: unknown): r is BaseRow {
   return (
     isObject(r) &&
     Object.hasOwn(r, 'id') &&
@@ -68,13 +68,13 @@ export function isBaseElement(r: unknown): r is BaseElement {
     Object.hasOwn(r, 'type') &&
     Object.hasOwn(r, 'attributes') &&
     Object.hasOwn(r, 'items') &&
-    typeof (r as BaseElement).id === 'string' &&
-    typeof (r as BaseElement).elementName === 'string' &&
-    typeof (r as BaseElement).size === 'number' &&
-    typeof (r as BaseElement).attributes === 'object' &&
-    isRowType((r as BaseElement).type) &&
-    Array.isArray((r as BaseElement).items) &&
-    (r as BaseElement).items.every((i: unknown) => typeof i === 'string')
+    typeof (r as BaseRow).id === 'string' &&
+    typeof (r as BaseRow).elementName === 'string' &&
+    typeof (r as BaseRow).size === 'number' &&
+    typeof (r as BaseRow).attributes === 'object' &&
+    isRowType((r as BaseRow).type) &&
+    Array.isArray((r as BaseRow).items) &&
+    (r as BaseRow).items.every((i: unknown) => typeof i === 'string')
   );
 }
 
@@ -289,16 +289,16 @@ export function isAggregate(a: unknown): a is Aggregate {
     isAggregateBy((a as Aggregate).aggregateBy) &&
     typeof (a as Aggregate).level === 'number' &&
     typeof (a as Aggregate).description === 'string' &&
-    (isSubsets((a as Aggregate).items) ||
-      (typeof (a as Aggregate).items === 'object' &&
-        Object.hasOwn((a as Aggregate).items, 'values') &&
-        Object.hasOwn((a as Aggregate).items, 'order') &&
-        typeof (a as Aggregate).items.values === 'object' &&
-        Object.entries((a as Aggregate).items.values).every(
+    (isSubsets((a as Aggregate).rows) ||
+      (typeof (a as Aggregate).rows === 'object' &&
+        Object.hasOwn((a as Aggregate).rows, 'values') &&
+        Object.hasOwn((a as Aggregate).rows, 'order') &&
+        typeof (a as Aggregate).rows.values === 'object' &&
+        Object.entries((a as Aggregate).rows.values).every(
           (k, v) => typeof k === 'string' && isAggregate(v),
         ) &&
-        Array.isArray((a as Aggregate).items.order) &&
-        (a as Aggregate).items.order.every((o: unknown) => typeof o === 'string')))
+        Array.isArray((a as Aggregate).rows.order) &&
+        (a as Aggregate).rows.order.every((o: unknown) => typeof o === 'string')))
   );
 }
 

--- a/packages/core/src/typecheck.ts
+++ b/packages/core/src/typecheck.ts
@@ -67,7 +67,7 @@ export function isBaseRow(r: unknown): r is BaseRow {
     Object.hasOwn(r, 'elementName') &&
     Object.hasOwn(r, 'size') &&
     Object.hasOwn(r, 'type') &&
-    Object.hasOwn(r, 'attributes') &&
+    Object.hasOwn(r, 'atts') &&
     typeof (r as BaseRow).id === 'string' &&
     typeof (r as BaseRow).elementName === 'string' &&
     typeof (r as BaseRow).size === 'number' &&
@@ -641,7 +641,7 @@ export function isUpsetConfig(config: unknown): config is UpsetConfig {
 
   // selected
   if (!(rowSelection === null || isRow(rowSelection))) {
-    console.warn('Upset config error: Selected is not a row');
+    console.warn('Upset config error: rowSelection is not a row');
     return false;
   }
 
@@ -655,7 +655,7 @@ export function isUpsetConfig(config: unknown): config is UpsetConfig {
   }
 
   // version
-  if (version !== '0.1.4') {
+  if (version !== '0.1.5') {
     console.warn('Upset config error: Invalid version');
     return false;
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,30 +100,30 @@ export type SixNumberSummary = {
   third?: number;
 };
 
-/**
- * Represents a list of attributes and their corresponding values.
- * The keys are attribute names and the values can be either a `SixNumberSummary` object or a number (deviation).
- */
-export type AttributeList = {
-  [attribute: string]: SixNumberSummary | number;
-};
+/** A list of attributes on a row; maps att names to summaries of the numerical props of the att */
+export type AttributeList = Record<string, SixNumberSummary>;
 
 /**
  * List of attributes for a subset ([attr1, attr2, deviation, degree, etc])
  */
-export type Attributes = AttributeList & {
-  /**
-   * The deviation of the subset.
-   */
-  deviation: number;
-  /**
-   * The degree of the subset.
-   */
-  degree?: number;
+export type Attributes = {
+  /** Atts computed by Upset */
+  derived: {
+    /**
+     * The deviation of the subset.
+     */
+    deviation: number;
+    /**
+     * The degree of the subset.
+     */
+    degree?: number;
+  };
+  /** Atts defined as table columns in the dataset */
+  dataset: AttributeList;
 };
 
 /**
- * Template for a row/intersection which can be a subset or an aggregate
+ * Template for a row/intersection which can be a subset or an aggregat e
  * @private typechecked by isBaseRow in typecheck.ts; changes here must be reflected there
  */
 export type BaseRow = {
@@ -151,7 +151,7 @@ export type BaseRow = {
   /**
    * The attributes of the element.
    */
-  attributes: Attributes;
+  atts: Attributes;
   /**
    * The parent element ID, if any.
    */
@@ -532,13 +532,18 @@ export type AccessibleDataEntry = {
   elementName: string;
   type: RowType;
   size: number;
-  attributes: Attributes;
+  /**
+   * Attributes of the data entry.
+   * @private Currently needs to be flat and named 'Attributes' to be compatible with the Upset text generator
+   */
+  attributes: Record<string, SixNumberSummary | number>;
   degree: number;
   id?: string;
   setMembership?: {
     [set: string]: SetMembershipStatus;
   };
-  items?: {
+  /** If this is an aggregate row, represents sub-rows */
+  rows?: {
     [row: string]: AccessibleDataEntry;
   };
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,23 +64,6 @@ export type Item = {
   atts: { [attr: string]: boolean | number | string };
 };
 
-/**
- * An item from the dataset which has been processed for a Vega plot in the element view.
- * All fields mapped from the record type should be numbers;
- * unfortunately there does not appear to be a way to enforce this in TypeScript.
- * @private This is separate from the Item type because atts need to be flattened and certain other properties
- * are necessary for compatibility with the Vega spec in generatePlotSpec.ts
- */
-export type VegaItem = {
-  subset?: string;
-  subsetName?: string;
-  color: string;
-  isCurrentSelected: boolean;
-  isCurrent: boolean;
-  bookmarked: boolean;
-  selectionType?: Omit<SelectionType, 'null'>;
-} & Record<string, string | number | boolean>;
-
 /** A list of items with labels mapped to item objects */
 export type Items = { [k: string]: Item };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -508,7 +508,7 @@ export type UpsetConfig = {
    * (values are stored in rowSelection, vegaSelection, and querySelection above)
    */
   selectionType: 'row' | 'vega' | 'query' | null;
-  version: '0.1.4';
+  version: '0.1.5';
   userAltText: AltText | null;
   /**
    * Whether to display numerical size labels on the intersection size bars.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -432,12 +432,12 @@ export type AltText = {
   /**
    * The long description for the Upset plot.
    */
-  longDescription: string | null;
+  longDescription: string;
 
   /**
    * The short description for the Upset plot.
    */
-  shortDescription: string | null;
+  shortDescription: string;
 
   /**
    * The technique description for the Upset plot.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,12 +57,14 @@ export type RowType =
   | 'Seperator'
   | 'Undefined';
 
+/** An item in the dataset; referred to in the UI as an element */
 export type Item = {
   _id: string;
   _label: string;
-  [attr: string]: boolean | number | string;
+  atts: { [attr: string]: boolean | number | string };
 };
 
+/** A list of items with labels mapped to item objects */
 export type Items = { [k: string]: Item };
 
 /** Items filtered by some query into included and excluded groups */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,23 @@ export type Item = {
   atts: { [attr: string]: boolean | number | string };
 };
 
+/**
+ * An item from the dataset which has been processed for a Vega plot in the element view.
+ * All fields mapped from the record type should be numbers;
+ * unfortunately there does not appear to be a way to enforce this in TypeScript.
+ * @private This is separate from the Item type because atts need to be flattened and certain other properties
+ * are necessary for compatibility with the Vega spec in generatePlotSpec.ts
+ */
+export type VegaItem = {
+  subset?: string;
+  subsetName?: string;
+  color: string;
+  isCurrentSelected: boolean;
+  isCurrent: boolean;
+  bookmarked: boolean;
+  selectionType?: Omit<SelectionType, 'null'>;
+} & Record<string, string | number | boolean>;
+
 /** A list of items with labels mapped to item objects */
 export type Items = { [k: string]: Item };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -559,3 +559,9 @@ export type AltTextConfig = UpsetConfig & {
   processedData?: AccessibleData;
   accessibleProcessedData?: AccessibleData;
 };
+
+export type JSONExport = UpsetConfig & {
+  rawData?: CoreUpsetData;
+  processedData?: Rows;
+  accessibleProcessedData?: AccessibleData;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,10 +121,10 @@ export type Attributes = AttributeList & {
 };
 
 /**
- * Represents a base element.
+ * Template for a row/intersection which can be a subset or an aggregate
  * @private typechecked by isBaseElement in typecheck.ts; changes here must be reflected there
  */
-export type BaseElement = {
+export type BaseRow = {
   /**
    * The ID of the element.
    */
@@ -135,8 +135,9 @@ export type BaseElement = {
   elementName: string;
   /**
    * The items associated with the element.
+   * Optional, as aggregates do not have items.
    */
-  items: string[];
+  items?: string[];
   /**
    * The type of the element.
    */
@@ -163,7 +164,7 @@ export const UNINCLUDED = 'unincluded';
  * Base Intersection type for subsets and aggregates.
  * @private typechecked by isBaseIntersection in typecheck.ts; changes here must be reflected there
  */
-export type BaseIntersection = BaseElement & {
+export type BaseIntersection = BaseRow & {
   setMembership: { [key: string]: SetMembershipStatus };
 };
 
@@ -216,7 +217,7 @@ export type Aggregate = Omit<Subset, 'items'> & {
   aggregateBy: AggregateBy;
   level: number;
   description: string;
-  items:
+  rows:
     | Subsets
     | {
         values: { [agg_id: string]: Aggregate };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -556,6 +556,6 @@ export type AccessibleData = {
 
 export type AltTextConfig = UpsetConfig & {
   rawData?: CoreUpsetData;
-  processedData?: Rows;
+  processedData?: AccessibleData;
   accessibleProcessedData?: AccessibleData;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -122,7 +122,7 @@ export type Attributes = AttributeList & {
 
 /**
  * Template for a row/intersection which can be a subset or an aggregate
- * @private typechecked by isBaseElement in typecheck.ts; changes here must be reflected there
+ * @private typechecked by isBaseRow in typecheck.ts; changes here must be reflected there
  */
 export type BaseRow = {
   /**

--- a/packages/core/src/typeutils.ts
+++ b/packages/core/src/typeutils.ts
@@ -54,31 +54,23 @@ export function querySelectionToString(selection: QuerySelection): string {
 /**
  * Checks if the given rows are aggregates.
  * @param rr The rows to check.
+ * @param allowEmpty Whether to allow an object devoid of rows (default: false).
  * @returns `true` if the rows are aggregates, `false` otherwise.
  */
-export function areRowsAggregates(rr: Rows): rr is Aggregates {
-  const { order } = rr;
-
-  if (order.length === 0) return false;
-
-  const row = rr.values[order[0]];
-
-  return row.type === 'Aggregate';
+export function areRowsAggregates(rr: Rows, allowEmpty = false): rr is Aggregates {
+  if (!allowEmpty && rr.order.length === 0) return false;
+  return rr.order.map((id) => rr.values[id].type).every((type) => type === 'Aggregate');
 }
 
 /**
  * Checks if the given rows are subsets.
  * @param rr - The rows to check.
+ * @param allowEmpty - Whether to allow an object devoid of rows (default: false).
  * @returns True if the rows are subsets, false otherwise.
  */
-export function areRowsSubsets(rr: Rows): rr is Subsets {
-  const { order } = rr;
-
-  if (order.length === 0) return false;
-
-  const row = rr.values[order[0]];
-
-  return row.type === 'Subset';
+export function areRowsSubsets(rr: Rows, allowEmpty = false): rr is Subsets {
+  if (!allowEmpty && rr.order.length === 0) return false;
+  return rr.order.map((id) => rr.values[id].type).every((type) => type === 'Subset');
 }
 
 /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -52,9 +52,9 @@ export function filterByVega(items: Item[], filter: VegaSelection): FilteredItem
     if (
       Object.entries(filter).every(
         ([key, value]) =>
-          typeof item[key] === 'number' &&
-          (item[key] as number) >= value[0] &&
-          (item[key] as number) <= value[1],
+          typeof item.atts[key] === 'number' &&
+          (item.atts[key] as number) >= value[0] &&
+          (item.atts[key] as number) <= value[1],
       )
     )
       included.push(item);
@@ -82,54 +82,54 @@ export function filterByQuery(items: Item[], filter: QuerySelection): FilteredIt
     if (Object.hasOwn(item, att)) {
       switch (type) {
         case ElementQueryType.CONTAINS:
-          add = `${item[att]}`.includes(query);
+          add = `${item.atts[att]}`.includes(query);
           break;
         case ElementQueryType.EQUALS:
-          switch (typeof item[att]) {
+          switch (typeof item.atts[att]) {
             case 'number':
-              add = Math.abs((item[att] as number) - Number(query)) < 0.0001;
+              add = Math.abs((item.atts[att] as number) - Number(query)) < 0.0001;
               break;
             case 'string':
-              add = `${item[att]}` === query;
+              add = `${item.atts[att]}` === query;
               break;
             default:
-              add = `${item[att]}` === query;
+              add = `${item.atts[att]}` === query;
           }
           break;
         case ElementQueryType.LENGTH:
-          add = `${item[att]}`.length === Number(query);
+          add = `${item.atts[att]}`.length === Number(query);
           break;
         case ElementQueryType.REGEX:
-          add = new RegExp(query).test(`${item[att]}`);
+          add = new RegExp(query).test(`${item.atts[att]}`);
           break;
         case ElementQueryType.GREATER_THAN:
-          switch (typeof item[att]) {
+          switch (typeof item.atts[att]) {
             case 'number':
-              add = Number(item[att]) > Number(query);
+              add = Number(item.atts[att]) > Number(query);
               break;
             case 'string':
               add =
-                `${item[att]}`.localeCompare(query, undefined, {
-                  numeric: typeof item[att] === 'number',
+                `${item.atts[att]}`.localeCompare(query, undefined, {
+                  numeric: typeof item.atts[att] === 'number',
                 }) > 0;
               break;
             default:
-              add = `${item[att]}` < `${query}`;
+              add = `${item.atts[att]}` < `${query}`;
           }
           break;
         case ElementQueryType.LESS_THAN:
-          switch (typeof item[att]) {
+          switch (typeof item.atts[att]) {
             case 'number':
-              add = Number(item[att]) < Number(query);
+              add = Number(item.atts[att]) < Number(query);
               break;
             case 'string':
               add =
-                `${item[att]}`.localeCompare(query, undefined, {
-                  numeric: typeof item[att] === 'number',
+                `${item.atts[att]}`.localeCompare(query, undefined, {
+                  numeric: typeof item.atts[att] === 'number',
                 }) < 0;
               break;
             default:
-              add = `${item[att]}` > `${query}`;
+              add = `${item.atts[att]}` > `${query}`;
           }
           break;
         default:

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -79,7 +79,7 @@ export function filterByQuery(items: Item[], filter: QuerySelection): FilteredIt
 
   items.forEach((item) => {
     let add = false;
-    if (Object.hasOwn(item, att)) {
+    if (Object.hasOwn(item.atts, att)) {
       switch (type) {
         case ElementQueryType.CONTAINS:
           add = `${item.atts[att]}`.includes(query);

--- a/packages/upset/src/atoms/attributeAtom.ts
+++ b/packages/upset/src/atoms/attributeAtom.ts
@@ -46,6 +46,7 @@ export const attributeValuesSelector = selectorFamily<number[], string>({
     ({ get }) => {
       const items = get(itemsAtom);
       const values = Object.values(items)
+        // Cast to number so we get the correct return type; this cast is guaranteed by the filter statement
         .map((item) => item.atts[attribute] as number)
         .filter((val) => !Number.isNaN(val));
 
@@ -91,7 +92,7 @@ const categorySizeOrderSelector = selectorFamily<string[], string>({
  * @returns {Object} Object with category names as keys and their counts as values
  */
 export const categoricalCountSelector = selectorFamily<
-  { [key: string]: number },
+  Record<string, number>,
   { row: string; attribute: string }
 >({
   key: 'categorical-count',
@@ -105,7 +106,7 @@ export const categoricalCountSelector = selectorFamily<
           acc[category] = 0;
           return acc;
         },
-        {} as { [key: string]: number },
+        {} as Record<string, number>,
       );
 
       items.forEach((item) => {
@@ -148,10 +149,7 @@ export const maxCategorySizeSelector = selectorFamily<number, string>({
  * @param {number} att Attribute to return category colors for
  * @returns A map of category names to colors
  */
-export const categoricalColorSelector = selectorFamily<
-  { [category: string]: string },
-  string
->({
+export const categoricalColorSelector = selectorFamily<Record<string, string>, string>({
   key: 'categorical-color',
   get:
     (att) =>
@@ -164,7 +162,7 @@ export const categoricalColorSelector = selectorFamily<
           }
           return acc;
         },
-        {} as { [category: string]: string },
+        {} as Record<string, string>,
       );
     },
 });

--- a/packages/upset/src/atoms/attributeAtom.ts
+++ b/packages/upset/src/atoms/attributeAtom.ts
@@ -46,7 +46,7 @@ export const attributeValuesSelector = selectorFamily<number[], string>({
     ({ get }) => {
       const items = get(itemsAtom);
       const values = Object.values(items)
-        .map((item) => item[attribute] as number)
+        .map((item) => item.atts[attribute] as number)
         .filter((val) => !Number.isNaN(val));
 
       return values;
@@ -68,7 +68,7 @@ const categorySizeOrderSelector = selectorFamily<string[], string>({
 
       const categories = items.reduce(
         (acc, item) => {
-          const value = item[attribute];
+          const value = item.atts[attribute];
           if (typeof value === 'string' && value) {
             acc[value] = (acc[value] || 0) + 1;
           }
@@ -109,8 +109,8 @@ export const categoricalCountSelector = selectorFamily<
       );
 
       items.forEach((item) => {
-        if (typeof item[attribute] !== 'string' || !item[attribute]) return;
-        const value = item[attribute];
+        if (typeof item.atts[attribute] !== 'string' || !item.atts[attribute]) return;
+        const value = item.atts[attribute];
         if (value in result) result[value] += 1;
         else result[value] = 1;
       });

--- a/packages/upset/src/atoms/dataAtom.ts
+++ b/packages/upset/src/atoms/dataAtom.ts
@@ -4,9 +4,17 @@ import { atom, selector } from 'recoil';
 /**
  * Atom to store the data for the Upset plot
  */
-export const dataAtom = atom<CoreUpsetData | Record<string, never>>({
+export const dataAtom = atom<CoreUpsetData>({
   key: 'data',
-  default: {},
+  default: {
+    label: '',
+    setColumns: [],
+    attributeColumns: [],
+    columns: [],
+    columnTypes: {},
+    items: {},
+    sets: {},
+  },
 });
 
 export const totalItemsSelector = selector<number>({

--- a/packages/upset/src/atoms/elementsSelectors.ts
+++ b/packages/upset/src/atoms/elementsSelectors.ts
@@ -185,10 +185,10 @@ export const attValuesSelector = selectorFamily<number[], { row: Row; att: strin
 
       // We could filter the whole array before we map, but attributes should all be the same type,
       // so its sufficient and more performant to only check the first attribute
-      if (!items[0] || !items[0][att] || typeof items[0][att] !== 'number') {
+      if (!items[0] || !items[0].atts[att] || typeof items[0].atts[att] !== 'number') {
         return [];
       }
-      return items.map((item) => item[att] as number);
+      return items.map((item) => item.atts[att] as number);
     },
 });
 

--- a/packages/upset/src/atoms/elementsSelectors.ts
+++ b/packages/upset/src/atoms/elementsSelectors.ts
@@ -280,7 +280,7 @@ export const aggregateSelectedCount = selectorFamily<
     ({ get }) => {
       let total = 0;
       Object.entries(
-        agg.items.values as { [id: string]: BaseIntersection | Aggregate },
+        agg.rows.values as { [id: string]: BaseIntersection | Aggregate },
       ).forEach(([id, value]) => {
         total += Object.prototype.hasOwnProperty.call(value, 'aggregateBy')
           ? get(aggregateSelectedCount({ agg: value as Aggregate, type }))

--- a/packages/upset/src/atoms/maxAtoms.ts
+++ b/packages/upset/src/atoms/maxAtoms.ts
@@ -6,7 +6,7 @@ export const maxDeviationSelector = selector({
   get: ({ get }) => {
     const rows = get(flattenedRowsSelector);
 
-    const deviations = rows.map((d) => Math.abs(d.row.attributes.deviation));
+    const deviations = rows.map((d) => Math.abs(d.row.atts.derived.deviation));
     const maxDeviation = Math.max(...deviations);
 
     return maxDeviation;

--- a/packages/upset/src/components/Columns/Attribute/AttributeBar.tsx
+++ b/packages/upset/src/components/Columns/Attribute/AttributeBar.tsx
@@ -57,7 +57,7 @@ export const AttributeBar: FC<Props> = ({ attribute, summary, row }) => {
    */
   const attPlotToRender: React.JSX.Element = useMemo(() => {
     // for every entry in attributePlotType, if the attribute matches the current attribute, return the corresponding plot
-    if (Object.keys(attributePlots).includes(attribute)) {
+    if (Object.keys(attributePlots).includes(attribute) && typeof summary !== 'number') {
       const plot = attributePlots[attribute];
 
       // render a dotplot for all rows <= 5, except for Strip Plots which encode the same information
@@ -75,7 +75,7 @@ export const AttributeBar: FC<Props> = ({ attribute, summary, row }) => {
 
       switch (plot) {
         case 'Box Plot':
-          return <BoxPlot scale={scale} summary={summary as SixNumberSummary} />;
+          return <BoxPlot scale={scale} summary={summary} />;
         case 'Strip Plot':
           return (
             <StripPlot

--- a/packages/upset/src/components/Columns/Attribute/AttributeBars.tsx
+++ b/packages/upset/src/components/Columns/Attribute/AttributeBars.tsx
@@ -52,7 +52,7 @@ export const AttributeBars: FC<Props> = memo(
       if (attribute === 'Degree')
         return <Degree degree={getDegreeFromSetMembership(row.setMembership)} />;
       if (attribute === 'Deviation')
-        return <DeviationBar deviation={row.attributes.deviation} />;
+        return <DeviationBar deviation={row.atts.derived.deviation} />;
       if (colTypes[attribute] === 'category')
         return (
           <CategoricalAttBar
@@ -63,7 +63,7 @@ export const AttributeBars: FC<Props> = memo(
         );
       return (
         <AttributeBar
-          summary={attributes[attribute]}
+          summary={attributes.dataset[attribute]}
           attribute={attribute}
           row={row}
           key={`${row}:${attribute}`}
@@ -105,8 +105,11 @@ export const AttributeBars: FC<Props> = memo(
   // Not checking the other attributes of the row object as they are not used in this component
   (prevProps, nextProps) =>
     prevProps.row.id === nextProps.row.id &&
-    Object.entries(prevProps.attributes).every(
+    prevProps.attributes.derived.deviation === nextProps.attributes.derived.deviation &&
+    prevProps.attributes.derived.degree === nextProps.attributes.derived.degree &&
+    Object.entries(prevProps.attributes.dataset).every(
       ([k, v]) =>
-        Object.keys(nextProps.attributes).includes(k) && nextProps.attributes[k] === v,
+        Object.keys(nextProps.attributes.dataset).includes(k) &&
+        nextProps.attributes.dataset[k] === v,
     ),
 );

--- a/packages/upset/src/components/Columns/Attribute/AttributePlots/MemoizedDensityVega.tsx
+++ b/packages/upset/src/components/Columns/Attribute/AttributePlots/MemoizedDensityVega.tsx
@@ -52,6 +52,7 @@ export const MemoizedDensityVega: FC<Props> = memo(
         spec={spec}
         actions={false}
         height={height}
+        // @ts-expect-error react-vega does not have types for css prop
         css={{ position: 'initial !important' }}
       />
     );

--- a/packages/upset/src/components/Columns/BookmarkColumnIcon.tsx
+++ b/packages/upset/src/components/Columns/BookmarkColumnIcon.tsx
@@ -103,7 +103,7 @@ export const BookmarkColumnIcon: FC<Props> = ({ row }) => {
       )}
       height={dimensions.body.rowHeight}
       width={dimensions.set.width}
-      onClick={(e: any) => handleClick(e)}
+      onClick={(e: never) => handleClick(e)}
     >
       <rect
         height={dimensions.body.rowHeight}
@@ -114,7 +114,7 @@ export const BookmarkColumnIcon: FC<Props> = ({ row }) => {
         <BookmarkIcon
           height={dimensions.body.rowHeight}
           width={dimensions.set.width}
-          fontSize={'1em' as any}
+          fontSize={'1em' as never}
           sx={{
             color,
             fillOpacity: opacity,
@@ -124,7 +124,7 @@ export const BookmarkColumnIcon: FC<Props> = ({ row }) => {
         <BookmarkBorderIcon
           height={dimensions.body.rowHeight}
           width={dimensions.set.width}
-          fontSize={'1em' as any}
+          fontSize={'1em' as never}
           sx={{
             color,
             fillOpacity: opacity,

--- a/packages/upset/src/components/Columns/SizeBar.tsx
+++ b/packages/upset/src/components/Columns/SizeBar.tsx
@@ -98,6 +98,7 @@ export const SizeBar: FC<Props> = ({ row, size, vegaSelected, querySelected }) =
    * @param index Index of the bar.
    * @returns Fill color for the bar.
    */
+  // eslint-disable-next-line no-unused-vars
   const getFillColor: (index: number) => string = useCallback(
     (index) => {
       // if the row is bookmarked, highlight the bar with the bookmark color
@@ -147,6 +148,7 @@ export const SizeBar: FC<Props> = ({ row, size, vegaSelected, querySelected }) =
    *   fullBars  Number of full bars to display.
    *   remainder Remaining size after full bars are displayed.
    */
+  // eslint-disable-next-line no-unused-vars
   const calculateBars: (rowSize: number) => { fullBars: number; remainder: number } =
     useCallback(
       (rowSize) => {
@@ -173,6 +175,7 @@ export const SizeBar: FC<Props> = ({ row, size, vegaSelected, querySelected }) =
    * @param uniqueId Unique identifier for the elements
    * @returns SVG elements for the line and tick
    */
+  // eslint-disable-next-line no-unused-vars
   const lineAndTick: (x: number, lineColor: string, index: number) => JSX.Element =
     useCallback(
       (x, lineColor, index) => (
@@ -213,6 +216,7 @@ export const SizeBar: FC<Props> = ({ row, size, vegaSelected, querySelected }) =
    * @param remainder Number of items remaining after full bars are calculated.
    * @returns Width of the size bar.
    */
+  // eslint-disable-next-line no-unused-vars
   const calculateWidth: (total: number, remainder: number) => number = useCallback(
     (total, remainder) => {
       let result = scale(remainder);

--- a/packages/upset/src/components/ElementView/AddPlot.tsx
+++ b/packages/upset/src/components/ElementView/AddPlot.tsx
@@ -143,7 +143,7 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
             id="x-select"
             value={x}
             label="X"
-            onChange={(event) => setX(event.target.value as string)}
+            onChange={(event) => setX(event.target.value)}
           >
             {attributeColumns.map((attr) => (
               <MenuItem key={attr} value={attr}>
@@ -162,7 +162,7 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
             id="y-select"
             value={y}
             label="Y"
-            onChange={(event) => setY(event.target.value as string)}
+            onChange={(event) => setY(event.target.value)}
           >
             {attributeColumns.map((attr) => (
               <MenuItem key={attr} value={attr}>
@@ -239,7 +239,7 @@ export const AddHistogram: FC<Props & { density: boolean }> = ({
             id="attribute-select"
             value={attribute}
             label="Attribute"
-            onChange={(event) => setAttribute(event.target.value as string)}
+            onChange={(event) => setAttribute(event.target.value)}
           >
             {attributeColumns.map((attr) => (
               <MenuItem key={attr} value={attr}>

--- a/packages/upset/src/components/ElementView/ElementSidebar.tsx
+++ b/packages/upset/src/components/ElementView/ElementSidebar.tsx
@@ -63,7 +63,7 @@ function downloadElementsAsCSV(items: Item[], columns: string[], name: string) {
     const row: string[] = [];
 
     columns.forEach((col) => {
-      row.push(item[col]?.toString() || '-');
+      row.push(item.atts[col]?.toString() || '-');
     });
 
     saveText.push(row.map((r) => (r.includes(',') ? `"${r}"` : r)).join(','));
@@ -72,7 +72,7 @@ function downloadElementsAsCSV(items: Item[], columns: string[], name: string) {
   const blob = new Blob([saveText.join('\n')], { type: 'text/csv' });
   const blobUrl = URL.createObjectURL(blob);
 
-  const anchor: any = document.createElement('a');
+  const anchor = document.createElement('a');
   anchor.style = 'display: none';
   document.body.appendChild(anchor);
   anchor.href = blobUrl;

--- a/packages/upset/src/components/ElementView/ElementTable.tsx
+++ b/packages/upset/src/components/ElementView/ElementTable.tsx
@@ -15,7 +15,8 @@ import { dataAttributeSelector } from '../../atoms/attributeAtom';
 function useRows(items: Item[]): GridRowsProp {
   return useMemo(() => {
     const newItems: GridRowsProp = items.map((item) => ({
-      ...item,
+      ...item.atts,
+      _label: item._label,
       id: item._id,
     }));
 

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -200,11 +200,11 @@ export const ElementVisualization = () => {
                 data={data}
                 actions={false}
                 signalListeners={{
-                  [BRUSH_NAME]: (_, val) => brushHandler(plot, val),
+                  [BRUSH_NAME]: (_: unknown, val: unknown) => brushHandler(plot, val),
                 }}
                 // Making room for the close button
                 style={{ marginLeft: '5px' }}
-                onNewView={(view) => {
+                onNewView={(view: View) => {
                   views.push({ view, plot });
                   setViews([...views]);
                   view.addEventListener('mouseover', () => {

--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -11,7 +11,7 @@ import {
   VegaSelection,
 } from '@visdesignlab/upset2-core';
 import { histogramSelector, scatterplotsSelector } from '../../atoms/config/plotAtoms';
-import { processedItemsSelector } from '../../atoms/elementsSelectors';
+import { vegaItemsSelector } from '../../atoms/elementsSelectors';
 import { generateVegaSpec } from './generatePlotSpec';
 import { ProvenanceContext } from '../Root';
 import { UpsetActions } from '../../provenance';
@@ -62,7 +62,7 @@ export const ElementVisualization = () => {
    */
   const scatterplots = useRecoilValue(scatterplotsSelector);
   const histograms = useRecoilValue(histogramSelector);
-  const items = useRecoilValue(processedItemsSelector);
+  const items = useRecoilValue(vegaItemsSelector);
   const selection = useRecoilValue(currentVegaSelection);
   const { actions }: { actions: UpsetActions } = useContext(ProvenanceContext);
   const selectionType = useRecoilValue(currentSelectionType);

--- a/packages/upset/src/components/ElementView/QueryInterface.tsx
+++ b/packages/upset/src/components/ElementView/QueryInterface.tsx
@@ -83,6 +83,7 @@ export const QueryInterface = () => {
     ) {
       actions.setQuerySelection({
         att: attField,
+        // This as cast is safe because we check the typeField against ElementQueryType prior to this conditional
         type: (typeField as ElementQueryType) || ElementQueryType.EQUALS,
         query: queryField,
       });

--- a/packages/upset/src/components/ElementView/generatePlotSpec.ts
+++ b/packages/upset/src/components/ElementView/generatePlotSpec.ts
@@ -58,12 +58,12 @@ export function createAddScatterplotSpec(
     },
     encoding: {
       x: {
-        field: x.attribute,
+        field: `atts.${x.attribute}`,
         type: 'quantitative',
         scale: { zero: false, type: x.logScale ? 'log' : 'linear' },
       },
       y: {
-        field: y.attribute,
+        field: `atts.${y.attribute}`,
         type: 'quantitative',
         scale: { zero: false, type: y.logScale ? 'log' : 'linear' },
       },
@@ -96,12 +96,12 @@ export function generateScatterplotSpec(spec: Scatterplot): VisualizationSpec {
     ],
     encoding: {
       x: {
-        field: spec.x,
+        field: `atts.${spec.x}`,
         type: 'quantitative',
         scale: { zero: false, type: spec.xScaleLog ? 'log' : 'linear' },
       },
       y: {
-        field: spec.y,
+        field: `atts.${spec.y}`,
         type: 'quantitative',
         scale: { zero: false, type: spec.yScaleLog ? 'log' : 'linear' },
       },
@@ -243,7 +243,7 @@ export function createAddHistogramSpec(
     encoding: {
       x: {
         bin: { maxbins: bins },
-        field: attribute,
+        field: `atts.${attribute}`,
       },
       y: { aggregate: 'count' },
     },
@@ -301,18 +301,22 @@ export function generateHistogramSpec(
         {
           // This layer shows all elements in grey
           transform: [
-            { density: hist.attribute },
+            { density: `atts.${hist.attribute}` },
             {
               // Hacky way to get the correct name for the attribute & sync with other plots
               // Otherwise, the attribute name is "value", so selections don't sync and the signal sent
               // by selecting on this plot doesn't include the name of the attribute being selected
               calculate: 'datum["value"]',
-              as: hist.attribute,
+              as: `atts.${hist.attribute}`,
             },
           ],
           mark: 'line',
           encoding: {
-            x: { field: hist.attribute, type: 'quantitative', title: hist.attribute },
+            x: {
+              field: `atts.${hist.attribute}`,
+              type: 'quantitative',
+              title: hist.attribute,
+            },
             y: { field: 'density', type: 'quantitative', title: 'Probability' },
             color: { value: DEFAULT_ELEMENT_COLOR },
             opacity: selectionTypeRow ? { value: 0.4 } : OPACITY,
@@ -323,12 +327,16 @@ export function generateHistogramSpec(
           params,
           transform: [
             { filter: { field: 'bookmarked', equal: true } },
-            { density: hist.attribute, groupby: ['subset', 'color'] },
-            { calculate: 'datum["value"]', as: hist.attribute },
+            { density: `atts.${hist.attribute}`, groupby: ['subset', 'color'] },
+            { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
           ],
           mark: 'line',
           encoding: {
-            x: { field: hist.attribute, type: 'quantitative', title: hist.attribute },
+            x: {
+              field: `atts.${hist.attribute}`,
+              type: 'quantitative',
+              title: hist.attribute,
+            },
             y: { field: 'density', type: 'quantitative', title: 'Probability' },
             color: COLOR,
             opacity: selectionTypeRow ? { value: 0.4 } : OPACITY,
@@ -338,12 +346,16 @@ export function generateHistogramSpec(
           // This layer displays probability density for selected elements
           transform: [
             { filter: { param: 'brush', empty: false } },
-            { density: hist.attribute },
-            { calculate: 'datum["value"]', as: hist.attribute },
+            { density: `atts.${hist.attribute}` },
+            { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
           ],
           mark: 'line',
           encoding: {
-            x: { field: hist.attribute, type: 'quantitative', title: hist.attribute },
+            x: {
+              field: `atts.${hist.attribute}`,
+              type: 'quantitative',
+              title: hist.attribute,
+            },
             y: { field: 'density', type: 'quantitative' },
             color: { value: vegaSelectionColor },
             opacity: { value: selectionTypeRow ? 0.4 : 1 },
@@ -354,14 +366,14 @@ export function generateHistogramSpec(
               {
                 transform: [
                   { filter: { field: 'isCurrent', equal: true } },
-                  { density: hist.attribute, groupby: ['subset', 'color'] },
-                  { calculate: 'datum["value"]', as: hist.attribute },
+                  { density: `atts.${hist.attribute}`, groupby: ['subset', 'color'] },
+                  { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
                 ],
                 mark: 'line' as AnyMark, // Vega is weird about some types in destructured objects
                 encoding: {
                   // More vega weirdness
                   x: {
-                    field: hist.attribute,
+                    field: `atts.${hist.attribute}`,
                     type: 'quantitative' as StandardType,
                     title: hist.attribute,
                   },
@@ -385,7 +397,7 @@ export function generateHistogramSpec(
         params,
         mark: 'bar',
         encoding: {
-          x: { bin: { maxbins: hist.bins }, field: hist.attribute },
+          x: { bin: { maxbins: hist.bins }, field: `atts.${hist.attribute}` },
           y: { aggregate: 'count', title: 'Frequency' },
           color: COLOR,
           opacity: OPACITY,
@@ -399,7 +411,11 @@ export function generateHistogramSpec(
         ],
         mark: 'bar',
         encoding: {
-          x: { field: hist.attribute, bin: { maxbins: hist.bins } },
+          x: {
+            field: `atts.${hist.attribute}`,
+            bin: { maxbins: hist.bins },
+            title: hist.attribute,
+          },
           y: { aggregate: 'count', title: 'Frequency' },
           color: { value: vegaSelectionColor },
           opacity: { value: 1 },
@@ -411,7 +427,7 @@ export function generateHistogramSpec(
               transform: [{ filter: { field: 'isCurrent', equal: true } }],
               mark: 'bar' as AnyMark, // Vega is weird about some types in destructured objects
               encoding: {
-                x: { field: hist.attribute, bin: { maxbins: hist.bins } },
+                x: { field: `atts.${hist.attribute}`, bin: { maxbins: hist.bins } },
                 y: { aggregate: 'count' as Aggregate, title: 'Frequency' },
                 color: COLOR,
                 opacity: { value: 1 },

--- a/packages/upset/src/components/ElementView/generatePlotSpec.ts
+++ b/packages/upset/src/components/ElementView/generatePlotSpec.ts
@@ -58,12 +58,12 @@ export function createAddScatterplotSpec(
     },
     encoding: {
       x: {
-        field: `atts.${x.attribute}`,
+        field: x.attribute,
         type: 'quantitative',
         scale: { zero: false, type: x.logScale ? 'log' : 'linear' },
       },
       y: {
-        field: `atts.${y.attribute}`,
+        field: y.attribute,
         type: 'quantitative',
         scale: { zero: false, type: y.logScale ? 'log' : 'linear' },
       },
@@ -96,12 +96,14 @@ export function generateScatterplotSpec(spec: Scatterplot): VisualizationSpec {
     ],
     encoding: {
       x: {
-        field: `atts.${spec.x}`,
+        field: spec.x,
+        title: spec.x,
         type: 'quantitative',
         scale: { zero: false, type: spec.xScaleLog ? 'log' : 'linear' },
       },
       y: {
-        field: `atts.${spec.y}`,
+        field: spec.y,
+        title: spec.y,
         type: 'quantitative',
         scale: { zero: false, type: spec.yScaleLog ? 'log' : 'linear' },
       },
@@ -243,7 +245,7 @@ export function createAddHistogramSpec(
     encoding: {
       x: {
         bin: { maxbins: bins },
-        field: `atts.${attribute}`,
+        field: attribute,
       },
       y: { aggregate: 'count' },
     },
@@ -301,19 +303,19 @@ export function generateHistogramSpec(
         {
           // This layer shows all elements in grey
           transform: [
-            { density: `atts.${hist.attribute}` },
+            { density: hist.attribute },
             {
               // Hacky way to get the correct name for the attribute & sync with other plots
               // Otherwise, the attribute name is "value", so selections don't sync and the signal sent
               // by selecting on this plot doesn't include the name of the attribute being selected
               calculate: 'datum["value"]',
-              as: `atts.${hist.attribute}`,
+              as: hist.attribute,
             },
           ],
           mark: 'line',
           encoding: {
             x: {
-              field: `atts.${hist.attribute}`,
+              field: hist.attribute,
               type: 'quantitative',
               title: hist.attribute,
             },
@@ -327,13 +329,13 @@ export function generateHistogramSpec(
           params,
           transform: [
             { filter: { field: 'bookmarked', equal: true } },
-            { density: `atts.${hist.attribute}`, groupby: ['subset', 'color'] },
-            { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
+            { density: hist.attribute, groupby: ['subset', 'color'] },
+            { calculate: 'datum["value"]', as: hist.attribute },
           ],
           mark: 'line',
           encoding: {
             x: {
-              field: `atts.${hist.attribute}`,
+              field: hist.attribute,
               type: 'quantitative',
               title: hist.attribute,
             },
@@ -346,13 +348,13 @@ export function generateHistogramSpec(
           // This layer displays probability density for selected elements
           transform: [
             { filter: { param: 'brush', empty: false } },
-            { density: `atts.${hist.attribute}` },
-            { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
+            { density: hist.attribute },
+            { calculate: 'datum["value"]', as: hist.attribute },
           ],
           mark: 'line',
           encoding: {
             x: {
-              field: `atts.${hist.attribute}`,
+              field: hist.attribute,
               type: 'quantitative',
               title: hist.attribute,
             },
@@ -366,14 +368,14 @@ export function generateHistogramSpec(
               {
                 transform: [
                   { filter: { field: 'isCurrent', equal: true } },
-                  { density: `atts.${hist.attribute}`, groupby: ['subset', 'color'] },
-                  { calculate: 'datum["value"]', as: `atts.${hist.attribute}` },
+                  { density: hist.attribute, groupby: ['subset', 'color'] },
+                  { calculate: 'datum["value"]', as: hist.attribute },
                 ],
                 mark: 'line' as AnyMark, // Vega is weird about some types in destructured objects
                 encoding: {
                   // More vega weirdness
                   x: {
-                    field: `atts.${hist.attribute}`,
+                    field: hist.attribute,
                     type: 'quantitative' as StandardType,
                     title: hist.attribute,
                   },
@@ -397,7 +399,7 @@ export function generateHistogramSpec(
         params,
         mark: 'bar',
         encoding: {
-          x: { bin: { maxbins: hist.bins }, field: `atts.${hist.attribute}` },
+          x: { bin: { maxbins: hist.bins }, field: hist.attribute },
           y: { aggregate: 'count', title: 'Frequency' },
           color: COLOR,
           opacity: OPACITY,
@@ -412,7 +414,7 @@ export function generateHistogramSpec(
         mark: 'bar',
         encoding: {
           x: {
-            field: `atts.${hist.attribute}`,
+            field: hist.attribute,
             bin: { maxbins: hist.bins },
             title: hist.attribute,
           },
@@ -427,7 +429,7 @@ export function generateHistogramSpec(
               transform: [{ filter: { field: 'isCurrent', equal: true } }],
               mark: 'bar' as AnyMark, // Vega is weird about some types in destructured objects
               encoding: {
-                x: { field: `atts.${hist.attribute}`, bin: { maxbins: hist.bins } },
+                x: { field: hist.attribute, bin: { maxbins: hist.bins } },
                 y: { aggregate: 'count' as Aggregate, title: 'Frequency' },
                 color: COLOR,
                 opacity: { value: 1 },

--- a/packages/upset/src/components/Header/AttributeScale.tsx
+++ b/packages/upset/src/components/Header/AttributeScale.tsx
@@ -14,9 +14,9 @@ type Props = {
 const defaultTickFormatter = (d: number) => {
   if (d >= 1000000) return `${d.toString()[0]}e${d.toString().length - 1}`;
 
-  if (d >= 500000) return `${(d as number) / 100000}M`;
+  if (d >= 500000) return `${d / 100000}M`;
 
-  if (d >= 1000) return `${(d as number) / 1000}K`;
+  if (d >= 1000) return `${d / 1000}K`;
 
   return d;
 };

--- a/packages/upset/src/components/Header/SetHeader.tsx
+++ b/packages/upset/src/components/Header/SetHeader.tsx
@@ -1,10 +1,8 @@
 import { ScaleLinear } from 'd3-scale';
-import { FC, useContext } from 'react';
+import React, { FC, useContext } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { a, useTransition } from 'react-spring';
 import { css } from '@mui/material';
-
-import { SortVisibleBy } from '@visdesignlab/upset2-core';
 import { dimensionsSelector } from '../../atoms/dimensionsAtom';
 import { setsAtom } from '../../atoms/setsAtoms';
 import { SetLabel } from '../custom/SetLabel';
@@ -83,7 +81,7 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
     {
       label: 'Sort Sets by Alphabetical',
       onClick: () => {
-        actions.sortVisibleBy('Alphabetical' as SortVisibleBy);
+        actions.sortVisibleBy('Alphabetical');
         handleContextMenuClose();
       },
       disabled: sortVisibleBy === 'Alphabetical',
@@ -91,7 +89,7 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
     {
       label: 'Sort Sets by Size - Ascending',
       onClick: () => {
-        actions.sortVisibleBy('Ascending' as SortVisibleBy);
+        actions.sortVisibleBy('Ascending');
         handleContextMenuClose();
       },
       disabled: sortVisibleBy === 'Ascending',
@@ -99,7 +97,7 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
     {
       label: 'Sort Sets by Size - Descending',
       onClick: () => {
-        actions.sortVisibleBy('Descending' as SortVisibleBy);
+        actions.sortVisibleBy('Descending');
         handleContextMenuClose();
       },
       disabled: sortVisibleBy === 'Descending',
@@ -112,7 +110,10 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
    * @param e - The mouse event that triggered the context menu.
    * @param setName - The name of the set.
    */
-  const openContextMenu = (e: MouseEvent, setName: string) => {
+  const openContextMenu = (
+    e: React.MouseEvent<SVGElement, MouseEvent>,
+    setName: string,
+  ) => {
     setContextMenu({
       mouseX: e.clientX,
       mouseY: e.clientY,
@@ -145,7 +146,7 @@ export const SetHeader: FC<Props> = ({ visibleSets, scale }) => {
         <a.g
           key={set.setName}
           transform={transform}
-          onContextMenu={(e: any) => {
+          onContextMenu={(e) => {
             e.preventDefault();
             e.stopPropagation();
             openContextMenu(e, set.setName);

--- a/packages/upset/src/components/Header/SizeHeader.tsx
+++ b/packages/upset/src/components/Header/SizeHeader.tsx
@@ -102,7 +102,7 @@ export const SizeHeader: FC = () => {
     },
   ];
 
-  const openContextMenu = (e: MouseEvent) => {
+  const openContextMenu = (e: React.MouseEvent<SVGGElement, MouseEvent>) => {
     setContextMenu({
       mouseX: e.clientX,
       mouseY: e.clientY,
@@ -165,6 +165,8 @@ export const SizeHeader: FC = () => {
         setSliding(false);
       });
 
+    // I truly hate to disable no-explicit-any here. If you want to try dealing with d3-drag types, good luck!
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     select(current).call(dragBehavior as any);
 
     return () => {
@@ -256,7 +258,7 @@ export const SizeHeader: FC = () => {
             }
           `}
           transform={translate(0, dimensions.size.scaleHeight + dimensions.size.gap)}
-          onContextMenu={(e: any) => {
+          onContextMenu={(e) => {
             e.preventDefault();
             e.stopPropagation();
             openContextMenu(e);

--- a/packages/upset/src/components/Root.tsx
+++ b/packages/upset/src/components/Root.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+  AltText,
   convertConfig,
   CoreUpsetData,
   DefaultConfig,
@@ -33,7 +34,6 @@ import { SvgBase } from './SvgBase';
 import { ContextMenu } from './ContextMenu';
 import { ProvenanceVis } from './ProvenanceVis';
 import { AltTextSidebar } from './AltTextSidebar';
-import { AltText } from '../types';
 import { footerHeightAtom } from '../atoms/dimensionsAtom';
 
 // Necessary defaults for the createContext; otherwise we have to type as | null and check that in every file that uses this context

--- a/packages/upset/src/components/Rows/AggregateRow.tsx
+++ b/packages/upset/src/components/Rows/AggregateRow.tsx
@@ -197,7 +197,7 @@ export const AggregateRow: FC<Props> = ({ aggregateRow }) => {
           vegaSelected={vegaSelected}
           querySelected={querySelected}
         />
-        <AttributeBars attributes={aggregateRow.attributes} row={aggregateRow} />
+        <AttributeBars attributes={aggregateRow.atts} row={aggregateRow} />
       </g>
     </g>
   );

--- a/packages/upset/src/components/Rows/SubsetRow.tsx
+++ b/packages/upset/src/components/Rows/SubsetRow.tsx
@@ -113,7 +113,7 @@ export const SubsetRow: FC<Props> = ({ subset }) => {
         vegaSelected={vegaSelected}
         querySelected={querySelected}
       />
-      <AttributeBars attributes={subset.attributes} row={subset} />
+      <AttributeBars attributes={subset.atts} row={subset} />
     </g>
   );
 };

--- a/packages/upset/src/components/SettingsSidebar.tsx
+++ b/packages/upset/src/components/SettingsSidebar.tsx
@@ -24,7 +24,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { AggregateBy, aggregateByList, BaseRow } from '@visdesignlab/upset2-core';
+import { aggregateByList, BaseRow, isAggregateBy } from '@visdesignlab/upset2-core';
 import React, {
   CSSProperties,
   FC,
@@ -117,6 +117,7 @@ type ToggleProps = {
   checked: boolean;
   /** The function to call when the toggle changes */
   onChange: (
+    // eslint-disable-next-line no-unused-vars
     ev: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLDivElement>,
   ) => void;
 };
@@ -386,7 +387,13 @@ export const SettingsSidebar = () => {
               <RadioGroup
                 value={firstAggregateBy}
                 onChange={(ev) => {
-                  const newAggBy: AggregateBy = ev.target.value as AggregateBy;
+                  const newAggBy = ev.target.value;
+                  if (!isAggregateBy(newAggBy)) {
+                    console.error(
+                      `Invalid aggregate by value: ${newAggBy}. Expected one of: ${aggregateByList.join(', ')}`,
+                    );
+                    return;
+                  }
                   actions.firstAggregateBy(newAggBy);
                 }}
               >
@@ -454,7 +461,13 @@ export const SettingsSidebar = () => {
                 <RadioGroup
                   value={secondAggregateBy}
                   onChange={(ev) => {
-                    const newAggBy: AggregateBy = ev.target.value as AggregateBy;
+                    const newAggBy = ev.target.value;
+                    if (!isAggregateBy(newAggBy)) {
+                      console.error(
+                        `Invalid aggregate by value: ${ev.target.value}. Expected one of: ${aggregateByList.join(', ')}`,
+                      );
+                      return;
+                    }
                     actions.secondAggregateBy(newAggBy);
                   }}
                 >

--- a/packages/upset/src/components/SettingsSidebar.tsx
+++ b/packages/upset/src/components/SettingsSidebar.tsx
@@ -24,7 +24,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { AggregateBy, aggregateByList, BaseElement } from '@visdesignlab/upset2-core';
+import { AggregateBy, aggregateByList, BaseRow } from '@visdesignlab/upset2-core';
 import React, {
   CSSProperties,
   FC,
@@ -340,7 +340,7 @@ export const SettingsSidebar = () => {
                 }
                 onChange={handleSetChange}
               >
-                {Object.values(allSets).map((set: BaseElement) => (
+                {Object.values(allSets).map((set: BaseRow) => (
                   <MenuItem key={set.id} value={set.id}>
                     <Checkbox checked={visibleSets.includes(set.id)} />
                     <ListItemText primary={set.elementName} />

--- a/packages/upset/src/components/SvgBase.tsx
+++ b/packages/upset/src/components/SvgBase.tsx
@@ -6,7 +6,6 @@ import translate from '../utils/transform';
 import { dimensionsSelector } from '../atoms/dimensionsAtom';
 import { ProvenanceContext } from './Root';
 import { currentIntersectionSelector } from '../atoms/config/selectionAtoms';
-import { calculateDimensions } from '../dimensions';
 import { queryBySetsInterfaceAtom } from '../atoms/config/queryBySetsAtoms';
 import { UpsetActions } from '../provenance';
 
@@ -18,7 +17,7 @@ export const SvgBase: FC = ({ children }) => {
 
   let { height } = dimensions;
 
-  if (dimensions as ReturnType<typeof calculateDimensions>) {
+  if (dimensions) {
     if (queryBySetsInterfaceOpen) {
       height += dimensions.setQuery.height + dimensions.setQuery.spacer;
     }

--- a/packages/upset/src/components/custom/Axis.tsx
+++ b/packages/upset/src/components/custom/Axis.tsx
@@ -20,9 +20,9 @@ type Props = {
 const defaultTickFormatter = (d: number) => {
   if (d >= 1000000) return `${d.toString()[0]}e${d.toString().length - 1}`;
 
-  if (d >= 500000) return `${(d as number) / 100000}M`;
+  if (d >= 500000) return `${d / 100000}M`;
 
-  if (d >= 1000) return `${(d as number) / 1000}K`;
+  if (d >= 1000) return `${d / 1000}K`;
 
   return d;
 };

--- a/packages/upset/src/components/custom/QueryBySet/QueryBySetInterface.tsx
+++ b/packages/upset/src/components/custom/QueryBySet/QueryBySetInterface.tsx
@@ -113,8 +113,8 @@ export const QueryBySetInterface = () => {
     let queryString = 'intersections of ';
 
     // 'May' sets have no string representation and so are ignored
-    const yesSets = membershipValues.filter((status) => status === 'Yes');
-    const noSets = membershipValues.filter((status) => status === 'No');
+    const yesSets = Object.entries(membership).filter(([_, status]) => status === 'Yes');
+    const noSets = Object.entries(membership).filter(([_, status]) => status === 'No');
 
     /**
      * YES SETS

--- a/packages/upset/src/components/custom/QueryBySet/QueryBySetInterface.tsx
+++ b/packages/upset/src/components/custom/QueryBySet/QueryBySetInterface.tsx
@@ -64,7 +64,7 @@ export const QueryBySetInterface = () => {
     });
 
     setMembership(newMembership);
-  }, [visibleSets, membership]);
+  }, [visibleSets]); // DO NOT add membership here, otherwise it will cause an infinite loop
 
   function handleEditQueryTitle() {
     // There is likely a better way to do this, but for now alert works fine.
@@ -113,8 +113,8 @@ export const QueryBySetInterface = () => {
     let queryString = 'intersections of ';
 
     // 'May' sets have no string representation and so are ignored
-    const yesSets = Object.entries(membership).filter(([_, status]) => status === 'Yes');
-    const noSets = Object.entries(membership).filter(([_, status]) => status === 'No');
+    const yesSets = membershipValues.filter((status) => status === 'Yes');
+    const noSets = membershipValues.filter((status) => status === 'No');
 
     /**
      * YES SETS

--- a/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
+++ b/packages/upset/src/components/custom/ReactMarkdownWrapper.tsx
@@ -4,14 +4,12 @@ import Markdown from 'react-markdown';
 // Wrapper for the Markdown component to parse and render the alt-txt json
 export default function ReactMarkdownWrapper({ text }: { text: string }) {
   const components = {
-    // eslint-disable-next-line jsx-a11y/heading-has-content
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     h1: ({ node, ...props }: { node: any }) => (
       <h3 id={node.children[0].value} {...props} />
     ),
-    // eslint-disable-next-line jsx-a11y/heading-has-content
-    p: ({ node, ...props }: { node: any }) => <Typography {...props} />,
-    // eslint-disable-next-line jsx-a11y/heading-has-content
-    ul: ({ node, ...props }: { node: any }) => (
+    p: ({ ...props }) => <Typography {...props} />,
+    ul: ({ ...props }) => (
       <ul
         {...props}
         // Matches the MUI typography style used for p elements

--- a/packages/upset/src/types.ts
+++ b/packages/upset/src/types.ts
@@ -1,4 +1,4 @@
-import { CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
+import { AltText, CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
 import { UpsetProvenance, UpsetActions } from './provenance';
 
 /**
@@ -14,32 +14,6 @@ export interface SidebarProps {
    * Callback function to close the sidebar.
    */
   close: () => void;
-}
-
-/**
- * Represents the alternative text for an Upset plot.
- */
-export interface AltText {
-  /**
-   * The long description for the Upset plot.
-   */
-  longDescription: string;
-
-  /**
-   * The short description for the Upset plot.
-   */
-  shortDescription: string;
-
-  /**
-   * The technique description for the Upset plot.
-   */
-  techniqueDescription: string;
-
-  /**
-   * Optional warnings for the Upset plot.
-   * Not yet implemented by the API as of 4/22/24
-   */
-  warnings?: string;
 }
 
 export type ContextMenuItem = {

--- a/packages/upset/src/types.ts
+++ b/packages/upset/src/types.ts
@@ -1,4 +1,9 @@
-import { AltText, CoreUpsetData, UpsetConfig } from '@visdesignlab/upset2-core';
+import {
+  AltText,
+  CoreUpsetData,
+  SelectionType,
+  UpsetConfig,
+} from '@visdesignlab/upset2-core';
 import { UpsetProvenance, UpsetActions } from './provenance';
 
 /**
@@ -65,6 +70,23 @@ export type ContextMenuInfo = {
 export interface UpsetItem {
   [key: string]: string | number | boolean;
 }
+
+/**
+ * An item from the dataset which has been processed for a Vega plot in the element view.
+ * All fields mapped from the record type should be numbers;
+ * unfortunately there does not appear to be a way to enforce this in TypeScript.
+ * @private This is separate from the Item type because atts need to be flattened and certain other properties
+ * are necessary for compatibility with the Vega spec in generatePlotSpec.ts
+ */
+export type VegaItem = {
+  subset?: string;
+  subsetName?: string;
+  color: string;
+  isCurrentSelected: boolean;
+  isCurrent: boolean;
+  bookmarked: boolean;
+  selectionType?: Omit<SelectionType, 'null'>;
+} & Record<string, string | number | boolean>;
 
 /**
  * Represents the props for the Upset component.

--- a/packages/upset/src/typeutils.ts
+++ b/packages/upset/src/typeutils.ts
@@ -1,0 +1,39 @@
+import { Item, Row, SelectionType } from '@visdesignlab/upset2-core';
+import { VegaItem } from './types';
+
+/**
+ * Converts an item to a VegaItem by flattening its attributes and adding selection properties
+ * @param item The item to convert
+ * @param currentIntersection The currently selected intersection, if any
+ * @param selectionType The current selection type
+ * @param defaultElementColor The default color for elements (not belonging to a subset) in the element view plots
+ * @param bookmarkProps If the item is a bookmark, this should be an object; otherwise, it should be false
+ *   @param bookmarkProps.rowID The ID of the row for the bookmark
+ *   @param bookmarkProps.rowName The name of the row for the bookmark
+ *   @param bookmarkProps.color The color of the bookmark (retrieved from the bookmarkColorSelector)
+ * @returns A VegaItem which can be passed in a list into the data field of a Vega plot;
+ *  these items are compatible with the Vega spec in generatePlotSpec.ts
+ */
+export function itemToVega(
+  item: Item,
+  currentIntersection: Row | null | undefined,
+  selectionType: SelectionType,
+  defaultElementColor: string,
+  bookmarkProps: { rowID: string; rowName: string; color: string } | false,
+): VegaItem {
+  return {
+    ...item.atts,
+    color: defaultElementColor,
+    ...(bookmarkProps
+      ? {
+          subset: bookmarkProps.rowID,
+          subsetName: bookmarkProps.rowName,
+          color: bookmarkProps.color,
+        }
+      : {}),
+    isCurrentSelected: !!currentIntersection,
+    isCurrent: bookmarkProps && currentIntersection?.id === bookmarkProps.rowID,
+    bookmarked: !!bookmarkProps,
+    ...(selectionType ? { selectionType } : {}),
+  };
+}

--- a/packages/upset/src/utils/exports.ts
+++ b/packages/upset/src/utils/exports.ts
@@ -1,6 +1,5 @@
 import {
   AccessibleData,
-  Aggregate,
   AltTextConfig,
   CoreUpsetData,
   Row,
@@ -85,10 +84,9 @@ const generateElementName = (rows: Rows): Rows => {
       let elName = splitElName.join(', ');
 
       if (splitElName.length > 1) {
-        if (r.type === 'Aggregate') {
-          const r2 = r as Aggregate;
+        if (isRowAggregate(r)) {
           // replace aggregate overlaps hyphen with " & " for better readability
-          if (r2.aggregateBy === 'Overlaps') {
+          if (r.aggregateBy === 'Overlaps') {
             elName = elName.split(' - ').join(' & ');
           }
         } else {

--- a/packages/upset/src/utils/exports.ts
+++ b/packages/upset/src/utils/exports.ts
@@ -2,6 +2,7 @@ import {
   AccessibleData,
   AltTextConfig,
   CoreUpsetData,
+  JSONExport,
   Row,
   Rows,
   UpsetConfig,
@@ -142,11 +143,8 @@ export const exportState = (
   rows?: Rows,
 ): void => {
   let filename = `upset_state_${new Date().toJSON().slice(0, 10)}`;
-  let dataObj = provenance.getState() as UpsetConfig & {
-    rawData?: CoreUpsetData;
-    processedData?: Rows;
-    accessibleProcessedData?: AccessibleData;
-  };
+  // Make a new type for the state download
+  let dataObj = provenance.getState() as JSONExport;
 
   if (data && rows) {
     const updatedRows = generateElementName(rows);

--- a/packages/upset/src/utils/exports.ts
+++ b/packages/upset/src/utils/exports.ts
@@ -28,7 +28,11 @@ export const getAccessibleData = (rows: Rows, includeId = false): AccessibleData
       elementName: r['elementName'],
       type: r['type'],
       size: r['size'],
-      attributes: r['attributes'],
+      attributes: {
+        ...r.atts.dataset,
+        ...(r.atts.derived.degree && { degree: r.atts.derived.degree }),
+        deviation: r.atts.derived.deviation,
+      },
       degree,
     };
 
@@ -37,7 +41,7 @@ export const getAccessibleData = (rows: Rows, includeId = false): AccessibleData
     }
 
     if (isRowAggregate(r)) {
-      data['values'][r['id']]['items'] = getAccessibleData(r['rows'], includeId).values;
+      data['values'][r['id']]['rows'] = getAccessibleData(r['rows'], includeId).values;
     } else {
       data['values'][r['id']]['setMembership'] = r['setMembership'];
     }

--- a/packages/upset/src/utils/exports.ts
+++ b/packages/upset/src/utils/exports.ts
@@ -125,7 +125,7 @@ export const getAltTextConfig = (
   dataObj = {
     ...dataObj,
     rawData: data,
-    processedData: updatedRows,
+    processedData: getAccessibleData(updatedRows),
     accessibleProcessedData: getAccessibleData(updatedRows),
   };
 

--- a/packages/upset/src/utils/exports.ts
+++ b/packages/upset/src/utils/exports.ts
@@ -37,7 +37,7 @@ export const getAccessibleData = (rows: Rows, includeId = false): AccessibleData
     }
 
     if (isRowAggregate(r)) {
-      data['values'][r['id']]['items'] = getAccessibleData(r['items'], includeId).values;
+      data['values'][r['id']]['items'] = getAccessibleData(r['rows'], includeId).values;
     } else {
       data['values'][r['id']]['setMembership'] = r['setMembership'];
     }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #556 

### Give a longer description of what this PR addresses and why it's needed
Previously, we had many unsafe type casts (ie using `as Type` without actually checking if the var is `Type`) and use of `any` in the repo. Additionally, the `Subset`, `Aggregate`, and `Item` types are set up as objects with defined fields that can also behave as a `Record`, which both defeats the purpose of having defined fields AND means that attributes from the dataset can overwrite built-in attributes. To fix the above, this PR does the following:
- Eliminates use of `any` in all but one location, which involves two external types
- Eliminates most uses of `as` casting, leaving only places where strictly necessary & type-safe
- Restructures the `Aggregate` type to have a `rows` field instead of an `items` field, so that it's now actually a subtype of `BaseRow` (renamed from `BaseElement` to avoid confusion with elements/items)
- Refactors the `Attributes` type to separate dataset & derived atts
- Gives the `Item` type an `atts` field to store non-builtin atts
- Refactors `elementsSelectors.ts` and related files to add a type `VegaItem` for the items fed to Vega plots and simplify the selectors
- Many other minor changes and fixes to enhance type safety

### Provide pictures/videos of the behavior before and after these changes (optional)
Literally no changes to appearance or behavior; the goal of this PR is to leave functionality unchanged while improving code quality.

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed