### PR TITLE
Standardize method for checking if an attribute is a derived (upset) attribute (as opposed to coming from the dataset

### DIFF
--- a/packages/app/src/components/DataTable.tsx
+++ b/packages/app/src/components/DataTable.tsx
@@ -1,5 +1,9 @@
 import { Backdrop, Box, Button, CircularProgress } from '@mui/material';
-import { AccessibleDataEntry, CoreUpsetData } from '@visdesignlab/upset2-core';
+import {
+  AccessibleDataEntry,
+  CoreUpsetData,
+  UPSET_ATTS,
+} from '@visdesignlab/upset2-core';
 import { useEffect, useMemo, useState } from 'react';
 import { DataGrid, GridColDef, GridRowsProp } from '@mui/x-data-grid';
 import { getAccessibleData } from '@visdesignlab/upset2-react';
@@ -252,8 +256,8 @@ export const DataTable = () => {
       Object.values(rows.values).forEach((r: AccessibleDataEntry) => {
         for (const key in r.attributes) {
           if (!cols.find((m) => m.field === key)) {
-            // skip deviation and degree. Deviation is added above and degree is not needed in the table
-            if (key === 'deviation' || key === 'degree') continue;
+            // skip derived atts. Deviation is added above and degree is not needed in the table
+            if (UPSET_ATTS.includes(key)) continue;
             cols.push({
               field: key,
               headerName: key,

--- a/packages/upset/src/components/SettingsSidebar.tsx
+++ b/packages/upset/src/components/SettingsSidebar.tsx
@@ -24,7 +24,12 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { aggregateByList, BaseRow, isAggregateBy } from '@visdesignlab/upset2-core';
+import {
+  aggregateByList,
+  BaseRow,
+  isAggregateBy,
+  UPSET_ATTS,
+} from '@visdesignlab/upset2-core';
 import React, {
   CSSProperties,
   FC,
@@ -230,10 +235,8 @@ export const SettingsSidebar = () => {
       // Ensures that the order is always Degree, Deviation, then the rest;
       // this keeps the plot consistent & prevents graphical bugs
       newAtts.sort((a, b) => {
-        if (a === 'Degree') return -1;
-        if (b === 'Degree') return 1;
-        if (a === 'Deviation') return -1;
-        if (b === 'Deviation') return 1;
+        if (UPSET_ATTS.includes(a)) return -1;
+        if (UPSET_ATTS.includes(b)) return 1;
         return 0;
       });
       // This simply sets the config visibleAtts to all newAtts, so it removes atts as well


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #368 

### Give a longer description of what this PR addresses and why it's needed
Tech debt change; ensures that we're always using the `UPSET_ATTS` const to check if an att is `'Degree'` or `'Deviation'`. No visual or functional changes.

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed