### PR TITLE
Add manage project and mange permissions buttons to app menu

### DIFF
--- a/packages/app/src/api/getMultinetDataUrl.ts
+++ b/packages/app/src/api/getMultinetDataUrl.ts
@@ -1,13 +1,28 @@
-import { multinetDatasets } from "./env";
+import { multinetDatasets } from './env';
 
 /**
  * Returns the URL for the Multinet data based on the provided workspace.
  * If no workspace is provided, the default Multinet datasets URL is returned.
  *
  * @param workspace - The workspace to fetch the URL for.
+ * @param queryParams - Optional query parameters to append to the URL.
+ *                      These should be provided as an object where keys are parameter names and values are parameter values
  * @returns The URL for the Multinet data.
  */
-export function getMultinetDataUrl(workspace?: string | null) {
-  if (workspace) return `${multinetDatasets}/#/workspaces/${workspace}`;
+export function getMultinetDataUrl(
+  workspace?: string | null,
+  queryParams?: Record<string, string | number | boolean>,
+): string {
+  if (workspace) {
+    if (queryParams) {
+      const queryString = Object.entries(queryParams)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&');
+      return `${multinetDatasets}/#/workspaces/${workspace}?${queryString}`;
+    }
+
+    return `${multinetDatasets}/#/workspaces/${workspace}`;
+  }
+
   return multinetDatasets;
 }

--- a/packages/app/src/components/Header/index.tsx
+++ b/packages/app/src/components/Header/index.tsx
@@ -273,7 +273,18 @@ const Header = ({ data }: { data: CoreUpsetData }) => {
                 }
               }}
             >
-              Load Data
+              Manage Project/Data
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                if (window) {
+                  window.location.href = getMultinetDataUrl(workspace, {
+                    permissions: 'true',
+                  });
+                }
+              }}
+            >
+              Manage Permissions
             </MenuItem>
             <DataTableLink
               data={data}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #426

### Give a longer description of what this PR addresses and why it's needed
Changes `load data` to `manage project/data` and adds `manage permissions` to the meatball menu in App.

The load data behavior is unchanged. Manage permissions opens the workspace and then opens the permissions menu

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="186" height="307" alt="image" src="https://github.com/user-attachments/assets/8b9827f3-696a-48f0-8d13-2916429e85da" />


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed