### PR TITLE
Right-clicking element view plots no longer clears the selection

### DIFF
--- a/packages/upset/src/components/ElementView/ElementVisualization.tsx
+++ b/packages/upset/src/components/ElementView/ElementVisualization.tsx
@@ -143,8 +143,10 @@ export const ElementVisualization = () => {
     draftSelection.current = null;
   }, [selection, actions, setColumnSelection]);
 
-  // Syncs the default value of the plots on load to the current numerical query
-  useEffect(() => {
+  /**
+   * Syncs all plots to the saved selection state
+   */
+  const syncSelection = useCallback(() => {
     preventSignal.current = true;
     const promises: Promise<void>[] = [];
     views.forEach(({ view }) => {
@@ -153,6 +155,11 @@ export const ElementVisualization = () => {
     Promise.allSettled(promises).then(() => {
       preventSignal.current = false;
     });
+  }, [views, selection]);
+
+  // Syncs the default value of the plots on load to the current numerical query
+  useEffect(() => {
+    syncSelection();
   }, [views, selection]);
 
   return (
@@ -178,6 +185,11 @@ export const ElementVisualization = () => {
               onContextMenu={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                // Vega clears plots on a right click, which we don't want. However, I haven't been able to get the Vega
+                // config to ignore right clicks (despite following the docs; try it yourself (: ) so instead we just
+                // re-sync the plots to the saved state after Vega clears them
+                // We delay the sync slightly to guarantee it happens after Vega's event handlers
+                setTimeout(syncSelection, 5);
                 setContextMenu({
                   mouseX: e.clientX,
                   mouseY: e.clientY,


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #540 

### Give a longer description of what this PR addresses and why it's needed
Previously, right-clicking element view plots to open the context menu would clear them; this is no longer the case

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed