### PR TITLE
Only use K formatting in attribute scale for numbers >4 digits

### DIFF
--- a/packages/upset/src/components/Header/AttributeScale.tsx
+++ b/packages/upset/src/components/Header/AttributeScale.tsx
@@ -16,7 +16,7 @@ const defaultTickFormatter = (d: number) => {
 
   if (d >= 500000) return `${d / 100000}M`;
 
-  if (d >= 1000) return `${d / 1000}K`;
+  if (d >= 10000) return `${d / 1000}K`;
 
   return d;
 };


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #575

### Give a longer description of what this PR addresses and why it's needed
This is a bandaid fix for 4-digit year scale displays. Years are now displayed correctly since 4-digit numbers are no longer abbreviated with the K notation. However, date attributes in all their permutations are not yet fully supported; I've made a new issue to address the broader concern.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="452" height="68" alt="Screenshot 2025-09-30 at 4 24 33 PM" src="https://github.com/user-attachments/assets/0144b40b-9061-4e9b-b6a2-be1241feddd9" />

After:
<img width="452" height="68" alt="Screenshot 2025-09-30 at 4 24 52 PM" src="https://github.com/user-attachments/assets/3a49485d-677e-458f-8454-b8f1f9acaab8" />

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed