### PR TITLE
Improve add plot modal performance

### DIFF
--- a/packages/upset/src/components/ElementView/AddPlot.tsx
+++ b/packages/upset/src/components/ElementView/AddPlot.tsx
@@ -24,6 +24,7 @@ import { VegaNamedData } from '../VegaLiteChart';
 
 type Props = {
   handleClose: () => void;
+  active: boolean;
 };
 
 type ButtonProps = {
@@ -123,12 +124,20 @@ const AddButton: FC<ButtonProps> = ({
 };
 
 const PLOT_CONTAINER_STYLE = { width: '100%', display: 'flex', justifyContent: 'center' };
+const EMPTY_PREVIEW_DATA: VegaNamedData = { elements: [] };
+const SCATTER_PREVIEW_ID = 'add-plot-scatter-preview';
+const HISTOGRAM_PREVIEW_ID = 'add-plot-histogram-preview';
 
-function createPreviewData(items: Items): VegaNamedData {
+function createPreviewData(items: Items, attributes: string[]): VegaNamedData {
+  const uniqueAttributes = Array.from(new Set(attributes));
+
   return {
-    elements: Object.values(items).map((item) => ({
-      ...item.atts,
-    })),
+    elements: Object.values(items).map((item) =>
+      uniqueAttributes.reduce<Record<string, unknown>>((acc, attribute) => {
+        acc[attribute] = item.atts[attribute];
+        return acc;
+      }, {}),
+    ),
   };
 }
 
@@ -136,14 +145,18 @@ function createPreviewData(items: Items): VegaNamedData {
  * UI for adding a scatterplot to the element view
  * @param param0 @see Props
  */
-export const AddScatterplot: FC<Props> = ({ handleClose }) => {
+export const AddScatterplot: FC<Props> = ({ handleClose, active }) => {
   const attributeColumns = useRecoilValue(dataAttributeSelector);
   const items = useRecoilValue(itemsAtom);
-  const previewData = useMemo(() => createPreviewData(items), [items]);
   const [x, setX] = useState<string>(attributeColumns[0]);
   const [y, setY] = useState<string>(attributeColumns[1]);
   const [xScaleLog, setXLogScale] = useState(false);
   const [yScaleLog, setYLogScale] = useState(false);
+  const hasItems = useMemo(() => Object.keys(items).length > 0, [items]);
+  const previewData = useMemo(() => {
+    if (!active || !x || !y) return EMPTY_PREVIEW_DATA;
+    return createPreviewData(items, [x, y]);
+  }, [active, items, x, y]);
 
   return (
     <Grid container spacing={1} sx={{ width: '100%', height: '100%' }}>
@@ -198,11 +211,11 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
           control={<Switch value={yScaleLog} onChange={() => setYLogScale(!yScaleLog)} />}
         />
       </Grid>
-      {x && y && Object.values(items).length && (
+      {active && x && y && hasItems && (
         <Box sx={PLOT_CONTAINER_STYLE}>
           <ScatterplotPlot
             spec={{
-              id: Date.now().toString(),
+              id: SCATTER_PREVIEW_ID,
               type: 'Scatterplot',
               x,
               y,
@@ -214,7 +227,7 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
         </Box>
       )}
       <AddButton
-        disabled={!(x && y && Object.values(items).length)}
+        disabled={!(x && y && hasItems)}
         handleClose={handleClose}
         type="Scatterplot"
         x={x}
@@ -232,13 +245,18 @@ export const AddScatterplot: FC<Props> = ({ handleClose }) => {
  */
 export const AddHistogram: FC<Props & { density: boolean }> = ({
   handleClose,
+  active,
   density,
 }) => {
   const items = useRecoilValue(itemsAtom);
   const attributeColumns = useRecoilValue(dataAttributeSelector);
-  const previewData = useMemo(() => createPreviewData(items), [items]);
   const [attribute, setAttribute] = useState(attributeColumns[0]);
   const [bins, setBins] = useState(20);
+  const hasItems = useMemo(() => Object.keys(items).length > 0, [items]);
+  const previewData = useMemo(() => {
+    if (!active || !attribute) return EMPTY_PREVIEW_DATA;
+    return createPreviewData(items, [attribute]);
+  }, [active, items, attribute]);
 
   return (
     <Grid container spacing={1} sx={{ width: '100%', height: '100%' }}>
@@ -278,11 +296,11 @@ export const AddHistogram: FC<Props & { density: boolean }> = ({
       )}
 
       <Grid container item xs={12}>
-        {attribute && bins > 0 && Object.values(items).length && (
+        {active && attribute && bins > 0 && hasItems && (
           <Box sx={PLOT_CONTAINER_STYLE}>
             <HistogramPlot
               spec={{
-                id: Date.now().toString(),
+                id: HISTOGRAM_PREVIEW_ID,
                 type: 'Histogram',
                 attribute,
                 bins,
@@ -293,7 +311,7 @@ export const AddHistogram: FC<Props & { density: boolean }> = ({
           </Box>
         )}
         <AddButton
-          disabled={!(attribute && bins > 0 && Object.values(items).length)}
+          disabled={!(attribute && bins > 0 && hasItems)}
           handleClose={handleClose}
           type="Histogram"
           attribute={attribute}

--- a/packages/upset/src/components/ElementView/AddPlotDialog.tsx
+++ b/packages/upset/src/components/ElementView/AddPlotDialog.tsx
@@ -13,23 +13,25 @@ type TabProps = {
 };
 
 function TabPanel({ children, index, value, ...others }: TabProps) {
+  const active = value === index;
+
   return (
     <Box
+      role="tabpanel"
+      hidden={!active}
       sx={{
         width: 600,
       }}
+      {...others}
     >
-      {value === index && (
-        <Box
-          sx={{
-            padding: '1em',
-            minHeight: 300,
-          }}
-          {...others}
-        >
-          {children}
-        </Box>
-      )}
+      <Box
+        sx={{
+          padding: '1em',
+          minHeight: 300,
+        }}
+      >
+        {children}
+      </Box>
     </Box>
   );
 }
@@ -43,7 +45,7 @@ export const AddPlotDialog: FC<Props> = ({ open, onClose }) => {
   const [currentTab, setCurrentTab] = useState<PlotType>('Scatterplot');
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} keepMounted>
       <DialogTitle>
         Add Plot
         <IconButton
@@ -69,13 +71,17 @@ export const AddPlotDialog: FC<Props> = ({ open, onClose }) => {
       </Tabs>
 
       <TabPanel index="Scatterplot" value={currentTab}>
-        <AddScatterplot handleClose={onClose} />
+        <AddScatterplot handleClose={onClose} active={currentTab === 'Scatterplot'} />
       </TabPanel>
       <TabPanel index="Histogram" value={currentTab}>
-        <AddHistogram handleClose={onClose} density={false} />
+        <AddHistogram
+          handleClose={onClose}
+          density={false}
+          active={currentTab === 'Histogram'}
+        />
       </TabPanel>
       <TabPanel index="KDE" value={currentTab}>
-        <AddHistogram handleClose={onClose} density />
+        <AddHistogram handleClose={onClose} density active={currentTab === 'KDE'} />
       </TabPanel>
     </Dialog>
   );

--- a/packages/upset/src/components/ElementView/HistogramPlot.tsx
+++ b/packages/upset/src/components/ElementView/HistogramPlot.tsx
@@ -1,5 +1,5 @@
 import { Histogram } from '@visdesignlab/upset2-core';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import { createAddHistogramSpec } from './generatePlotSpec';
 import { VegaLiteChart, VegaNamedData } from '../VegaLiteChart';
@@ -9,10 +9,11 @@ type Props = {
   data: VegaNamedData;
 };
 
-export const HistogramPlot: FC<Props> = ({ spec, data }) => (
-  <VegaLiteChart
-    spec={createAddHistogramSpec(spec.attribute, spec.bins, spec.frequency)}
-    data={data}
-    actions={false}
-  />
-);
+export const HistogramPlot: FC<Props> = ({ spec, data }) => {
+  const chartSpec = useMemo(
+    () => createAddHistogramSpec(spec.attribute, spec.bins, spec.frequency),
+    [spec.attribute, spec.bins, spec.frequency],
+  );
+
+  return <VegaLiteChart spec={chartSpec} data={data} actions={false} />;
+};

--- a/packages/upset/src/components/ElementView/Scatterplot.tsx
+++ b/packages/upset/src/components/ElementView/Scatterplot.tsx
@@ -1,5 +1,5 @@
 import { Scatterplot } from '@visdesignlab/upset2-core';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import { createAddScatterplotSpec } from './generatePlotSpec';
 import { VegaLiteChart, VegaNamedData } from '../VegaLiteChart';
@@ -9,19 +9,21 @@ type Props = {
   data: VegaNamedData;
 };
 
-export const ScatterplotPlot: FC<Props> = ({ spec, data }) => (
-  <VegaLiteChart
-    spec={createAddScatterplotSpec(
-      {
-        attribute: spec.x,
-        logScale: spec.xScaleLog || false,
-      },
-      {
-        attribute: spec.y,
-        logScale: spec.yScaleLog || false,
-      },
-    )}
-    data={data}
-    actions={false}
-  />
-);
+export const ScatterplotPlot: FC<Props> = ({ spec, data }) => {
+  const chartSpec = useMemo(
+    () =>
+      createAddScatterplotSpec(
+        {
+          attribute: spec.x,
+          logScale: spec.xScaleLog || false,
+        },
+        {
+          attribute: spec.y,
+          logScale: spec.yScaleLog || false,
+        },
+      ),
+    [spec.x, spec.y, spec.xScaleLog, spec.yScaleLog],
+  );
+
+  return <VegaLiteChart spec={chartSpec} data={data} actions={false} />;
+};


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This reduces unnecessary work in the add plot modal by keeping dialog tabs mounted, only rendering the active preview, and preserving modal state across tab switches and reopen.

It also makes preview generation cheaper by projecting only the attributes needed for the current preview instead of cloning every item’s full attribute payload, removes repeated full-item scans used only for emptiness checks, and memoizes preview Vega specs to avoid extra chart churn when inputs have not changed.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] manual testing
