### PR TITLE
Fix Vega 6 peer dependency compatibility

### DIFF
--- a/packages/upset/package.json
+++ b/packages/upset/package.json
@@ -49,13 +49,13 @@
     "@mui/x-data-grid": "^8.1.0",
     "@trrack/core": "^1.6.1",
     "@trrack/vis-react": "^1.6.1",
-    "react": "^18.3.1 || ^19.0.0",
-    "react-dom": "^18.3.1 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-vega": "^8.0.0",
     "recoil": "^0.5.2",
     "vega": "^6.2.0",
     "vega-embed": "^7.0.2",
-    "vega-lite": "^5.2.0"
+    "vega-lite": "^6.0.1"
   },
   "peerDependenciesMeta": {
     "@trrack/vis-react": {
@@ -89,7 +89,7 @@
     "typescript": "^5.9.3",
     "vega": "^6.2.0",
     "vega-embed": "^7.0.2",
-    "vega-lite": "^5.2.0"
+    "vega-lite": "^6.4.3"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/upset/src/components/ElementView/generatePlotSpec.ts
+++ b/packages/upset/src/components/ElementView/generatePlotSpec.ts
@@ -6,14 +6,24 @@ import {
   Scatterplot,
   SelectionType,
 } from '@visdesignlab/upset2-core';
-import { SelectionParameter } from 'vega-lite/build/src/selection';
-import { Predicate } from 'vega-lite/build/src/predicate';
-import { LogicalComposition } from 'vega-lite/build/src/logical';
-import { AnyMark } from 'vega-lite/build/src/mark';
-import { Aggregate } from 'vega-lite/build/src/aggregate';
-import { StandardType } from 'vega-lite/build/src/type';
 import { VisualizationSpec } from 'vega-embed/build/embed';
 import { DEFAULT_ELEMENT_COLOR, vegaSelectionColor } from '../../utils/styles';
+
+type IntervalSelectionParameter = {
+  name: string;
+  select: {
+    type: 'interval';
+    encodings?: Array<'x' | 'y'>;
+    clear?: string;
+  };
+};
+
+type BrushLogicalComposition =
+  | { and: BrushLogicalComposition[] }
+  | { or: BrushLogicalComposition[] }
+  | { not: BrushLogicalComposition }
+  | { param: string; empty?: boolean }
+  | { field: string; equal: string | boolean };
 
 /**
  * Janky gadget which can be inserted into a condition and returns TRUE if the brush param is empty
@@ -21,7 +31,7 @@ import { DEFAULT_ELEMENT_COLOR, vegaSelectionColor } from '../../utils/styles';
  *          the right-side predicate evaluates to true if the item is selected OR the brush is empty.
  *          This creates a logical gadget that evaluates to true if the brush is empty regardless of the item state.
  */
-const BRUSH_EMPTY: LogicalComposition<Predicate> = {
+const BRUSH_EMPTY: BrushLogicalComposition = {
   and: [{ not: { param: 'brush', empty: false } }, { param: 'brush' }],
 };
 
@@ -59,12 +69,12 @@ export function createAddScatterplotSpec(
     encoding: {
       x: {
         field: x.attribute,
-        type: 'quantitative',
+        type: 'quantitative' as const,
         scale: { zero: false, type: x.logScale ? 'log' : 'linear' },
       },
       y: {
         field: y.attribute,
-        type: 'quantitative',
+        type: 'quantitative' as const,
         scale: { zero: false, type: y.logScale ? 'log' : 'linear' },
       },
     },
@@ -98,13 +108,13 @@ export function generateScatterplotSpec(spec: Scatterplot): VisualizationSpec {
       x: {
         field: spec.x,
         title: spec.x,
-        type: 'quantitative',
+        type: 'quantitative' as const,
         scale: { zero: false, type: spec.xScaleLog ? 'log' : 'linear' },
       },
       y: {
         field: spec.y,
         title: spec.y,
-        type: 'quantitative',
+        type: 'quantitative' as const,
         scale: { zero: false, type: spec.yScaleLog ? 'log' : 'linear' },
       },
       color: {
@@ -227,8 +237,8 @@ export function createAddHistogramSpec(
       ],
       mark: 'line',
       encoding: {
-        x: { field: 'value', type: 'quantitative' },
-        y: { field: 'density', type: 'quantitative' },
+        x: { field: 'value', type: 'quantitative' as const },
+        y: { field: 'density', type: 'quantitative' as const },
       },
     };
 
@@ -247,7 +257,7 @@ export function createAddHistogramSpec(
         bin: { maxbins: bins },
         field: attribute,
       },
-      y: { aggregate: 'count' },
+      y: { aggregate: 'count' as const },
     },
   };
 
@@ -275,7 +285,7 @@ export function generateHistogramSpec(
         clear: 'mousedown',
       },
     },
-  ] as SelectionParameter[];
+  ] as IntervalSelectionParameter[];
 
   /** Color for layers showing all elements (not selection layers) */
   const COLOR = {
@@ -312,14 +322,14 @@ export function generateHistogramSpec(
               as: hist.attribute,
             },
           ],
-          mark: 'line',
+          mark: 'line' as const,
           encoding: {
             x: {
               field: hist.attribute,
-              type: 'quantitative',
+              type: 'quantitative' as const,
               title: hist.attribute,
             },
-            y: { field: 'density', type: 'quantitative', title: 'Probability' },
+            y: { field: 'density', type: 'quantitative' as const, title: 'Probability' },
             color: { value: DEFAULT_ELEMENT_COLOR },
             opacity: selectionTypeRow ? { value: 0.4 } : OPACITY,
           },
@@ -332,14 +342,14 @@ export function generateHistogramSpec(
             { density: hist.attribute, groupby: ['subset', 'color'] },
             { calculate: 'datum["value"]', as: hist.attribute },
           ],
-          mark: 'line',
+          mark: 'line' as const,
           encoding: {
             x: {
               field: hist.attribute,
-              type: 'quantitative',
+              type: 'quantitative' as const,
               title: hist.attribute,
             },
-            y: { field: 'density', type: 'quantitative', title: 'Probability' },
+            y: { field: 'density', type: 'quantitative' as const, title: 'Probability' },
             color: COLOR,
             opacity: selectionTypeRow ? { value: 0.4 } : OPACITY,
           },
@@ -351,14 +361,14 @@ export function generateHistogramSpec(
             { density: hist.attribute },
             { calculate: 'datum["value"]', as: hist.attribute },
           ],
-          mark: 'line',
+          mark: 'line' as const,
           encoding: {
             x: {
               field: hist.attribute,
-              type: 'quantitative',
+              type: 'quantitative' as const,
               title: hist.attribute,
             },
-            y: { field: 'density', type: 'quantitative' },
+            y: { field: 'density', type: 'quantitative' as const },
             color: { value: vegaSelectionColor },
             opacity: { value: selectionTypeRow ? 0.4 : 1 },
           },
@@ -371,15 +381,15 @@ export function generateHistogramSpec(
                 { density: hist.attribute, groupby: ['subset', 'color'] },
                 { calculate: 'datum["value"]', as: hist.attribute },
               ],
-              mark: 'line' as AnyMark, // Vega is weird about some types in destructured objects
+              mark: 'line' as const,
               encoding: {
                 // More vega weirdness
                 x: {
                   field: hist.attribute,
-                  type: 'quantitative' as StandardType,
+                  type: 'quantitative' as const,
                   title: hist.attribute,
                 },
-                y: { field: 'density', type: 'quantitative' as StandardType },
+                y: { field: 'density', type: 'quantitative' as const },
                 color: COLOR,
                 opacity: { value: 1 },
               },
@@ -397,10 +407,10 @@ export function generateHistogramSpec(
     layer: [
       {
         params,
-        mark: 'bar',
+        mark: 'bar' as const,
         encoding: {
           x: { bin: { maxbins: hist.bins }, field: hist.attribute },
-          y: { aggregate: 'count', title: 'Frequency' },
+          y: { aggregate: 'count' as const, title: 'Frequency' },
           color: COLOR,
           opacity: OPACITY,
         },
@@ -411,14 +421,14 @@ export function generateHistogramSpec(
             filter: { param: 'brush', empty: false },
           },
         ],
-        mark: 'bar',
+        mark: 'bar' as const,
         encoding: {
           x: {
             field: hist.attribute,
             bin: { maxbins: hist.bins },
             title: hist.attribute,
           },
-          y: { aggregate: 'count', title: 'Frequency' },
+          y: { aggregate: 'count' as const, title: 'Frequency' },
           color: { value: vegaSelectionColor },
           opacity: { value: 1 },
         },
@@ -427,10 +437,10 @@ export function generateHistogramSpec(
         ? [
           {
             transform: [{ filter: { field: 'isCurrent', equal: true } }],
-            mark: 'bar' as AnyMark, // Vega is weird about some types in destructured objects
+            mark: 'bar' as const,
             encoding: {
               x: { field: hist.attribute, bin: { maxbins: hist.bins } },
-              y: { aggregate: 'count' as Aggregate, title: 'Frequency' },
+              y: { aggregate: 'count' as const, title: 'Frequency' },
               color: COLOR,
               opacity: { value: 1 },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6118,14 +6118,14 @@ cli-truncate@^5.0.0:
     slice-ansi "^8.0.0"
     string-width "^8.2.0"
 
-cliui@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
-  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+cliui@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-9.0.1.tgz#6f7890f386f6f1f79953adc1f78dec46fcc2d291"
+  integrity sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==
   dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
+    string-width "^7.2.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -12530,11 +12530,6 @@ repeat-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -13210,16 +13205,7 @@ string-argv@^0.3.2, string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13237,7 +13223,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string-width@^7.0.0:
+string-width@^7.0.0, string-width@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
@@ -13353,14 +13339,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14179,11 +14158,6 @@ vega-event-selector@^4.0.0, vega-event-selector@~4.0.0:
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-4.0.0.tgz#425e9f2671e858a1a45b4b6a7fc452ca0b22abbf"
   integrity sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==
 
-vega-event-selector@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-3.0.1.tgz#b99e92147b338158f8079d81b28b2e7199c2e259"
-  integrity sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==
-
 vega-expression@^6.1.0, vega-expression@~6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-6.1.0.tgz#6ce358a39b9b953806bff200f6f84f44163c9e38"
@@ -14191,14 +14165,6 @@ vega-expression@^6.1.0, vega-expression@~6.1.0:
   dependencies:
     "@types/estree" "^1.0.8"
     vega-util "^2.1.0"
-
-vega-expression@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.1.2.tgz#1ed0677787b8e5f4047c9b847ecc20da0a2a8d05"
-  integrity sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    vega-util "^1.17.3"
 
 vega-force@~5.1.0:
   version "5.1.0"
@@ -14277,17 +14243,17 @@ vega-label@~2.1.0:
     vega-scenegraph "^5.1.0"
     vega-util "^2.1.0"
 
-vega-lite@^5.2.0:
-  version "5.23.0"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.23.0.tgz#342cbe8e5ccd3e3eeb4721818b1d5cb26b60ad8a"
-  integrity sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==
+vega-lite@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-6.4.3.tgz#9973d3afe1391fb08807bc2585e129e2daf7a36b"
+  integrity sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==
   dependencies:
     json-stringify-pretty-compact "~4.0.0"
     tslib "~2.8.1"
-    vega-event-selector "~3.0.1"
-    vega-expression "~5.1.1"
-    vega-util "~1.17.2"
-    yargs "~17.7.2"
+    vega-event-selector "~4.0.0"
+    vega-expression "~6.1.0"
+    vega-util "~2.1.0"
+    yargs "~18.0.0"
 
 vega-loader@^5.1.0, vega-loader@~5.1.0:
   version "5.1.0"
@@ -14423,11 +14389,6 @@ vega-typings@~2.1.0:
     vega-event-selector "^4.0.0"
     vega-expression "^6.1.0"
     vega-util "^2.1.0"
-
-vega-util@^1.17.3, vega-util@~1.17.2:
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.4.tgz#b35781fe8e8d030e6519746682843d7ef9ff6d27"
-  integrity sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==
 
 vega-util@^2.0.0, vega-util@^2.1.0, vega-util@~2.1.0:
   version "2.1.0"
@@ -14844,16 +14805,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14954,23 +14906,22 @@ yargs-parser@20.x:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+yargs-parser@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
+  integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
-yargs@~17.7.2:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+yargs@~18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.0.0.tgz#6c84259806273a746b09f579087b68a3c2d25bd1"
+  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
   dependencies:
-    cliui "^8.0.1"
+    cliui "^9.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
+    string-width "^7.2.0"
     y18n "^5.0.5"
-    yargs-parser "^21.1.1"
+    yargs-parser "^22.0.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- align upset2-react peer dependencies on the Vega 6 stack
- update the local Vega-Lite dev dependency and lockfile to 6.x
- remove Vega-Lite private type imports so the package typechecks and builds with Vega-Lite 6

## Validation
- yarn install
- yarn --cwd packages/upset typecheck
- yarn --cwd packages/upset build
- clean npm install in a temp app with React 18, react-vega 8, vega 6, and vega-lite 6
